### PR TITLE
fix(command-parser): case-insensitive verb matching

### DIFF
--- a/src/services/command-parser.ts
+++ b/src/services/command-parser.ts
@@ -66,7 +66,7 @@ export function parseCommand(body: unknown): ParsedCommand | null {
 
   if (remainder.length > 0) {
     const tokenMatch = FIRST_TOKEN_PATTERN.exec(remainder);
-    const firstToken = tokenMatch?.[1] ?? "";
+    const firstToken = (tokenMatch?.[1] ?? "").toLowerCase();
 
     if (KNOWN_VERBS.has(firstToken)) {
       verb = firstToken as CommandVerb;

--- a/tests/unit/command-parser.test.ts
+++ b/tests/unit/command-parser.test.ts
@@ -86,4 +86,36 @@ describe("parseCommand", () => {
       additionalInstructions: "",
     });
   });
+
+  test("matches the verb case-insensitively (capitalized)", () => {
+    assert.deepEqual(parseCommand("/claude Implement"), {
+      agent: "claude",
+      verb: "implement",
+      additionalInstructions: "",
+    });
+  });
+
+  test("matches the verb case-insensitively with trailing instructions", () => {
+    assert.deepEqual(parseCommand("/claude IMPLEMENT add tests"), {
+      agent: "claude",
+      verb: "implement",
+      additionalInstructions: "add tests",
+    });
+  });
+
+  test("matches the verb case-insensitively (mixed case)", () => {
+    assert.deepEqual(parseCommand("/claude ImPlEmEnT"), {
+      agent: "claude",
+      verb: "implement",
+      additionalInstructions: "",
+    });
+  });
+
+  test("does not match a verb that only starts with a known verb", () => {
+    assert.deepEqual(parseCommand("/claude implementation foo"), {
+      agent: "claude",
+      verb: null,
+      additionalInstructions: "implementation foo",
+    });
+  });
 });

--- a/tests/unit/event-dispatcher.test.ts
+++ b/tests/unit/event-dispatcher.test.ts
@@ -141,6 +141,22 @@ describe("EventDispatcher", () => {
     assert.equal(action.instructionId, "pr-implement");
   });
 
+  test("maps /claude Implement (capitalized) on a PR to pr-implement", () => {
+    const dispatcher = makeDispatcher();
+
+    const action = dispatcher.dispatch({
+      kind: "pr_comment",
+      repo,
+      pr: pr({ number: 52 }),
+      comment: { body: "/claude Implement" },
+      sender: { id: 100, login: "alice" },
+    });
+
+    assert.equal(action.kind, "enqueue");
+    if (action.kind !== "enqueue") return;
+    assert.equal(action.instructionId, "pr-implement");
+  });
+
   test("rejects /claude implement on a fork PR with a comment", () => {
     const dispatcher = makeDispatcher();
 


### PR DESCRIPTION
## Summary
- Normalize the first token after the agent to lowercase before checking `KNOWN_VERBS` so `/claude Implement`, `/claude IMPLEMENT`, `/claude ImPlEmEnT` all dispatch as `verb=implement`.
- Add 4 parser cases (3 case variants + 1 regression) and 1 dispatcher case (`/claude Implement` → `pr-implement`).

## Test plan
- [x] `npm test` (130 tests pass)

Resolves #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)