### PR TITLE
fix(execution): post fallback comments on mutate silent failures

### DIFF
--- a/src/services/execution-service.ts
+++ b/src/services/execution-service.ts
@@ -253,13 +253,28 @@ export class ExecutionService {
         });
 
       if (agentResult.exitCode !== 0) {
-        return this.fail(input.task.taskId, agentResult.stderr || agentResult.stdout);
+        const summary = (agentResult.stderr || agentResult.stdout).trim();
+        await this.postSourceComment(
+          input,
+          this.withInstructionFooter(
+            `Ran \`/claude implement\`: agent exited with code ${agentResult.exitCode}.\n\n${truncate(summary, 1500)}`,
+            input.instruction,
+          ),
+        );
+        return this.fail(input.task.taskId, summary);
       }
 
       const hasChanges =
         await this.dependencies.workspaceManager.hasChanges(workspace);
 
       if (!hasChanges) {
+        await this.postSourceComment(
+          input,
+          this.withInstructionFooter(
+            "Ran `/claude implement`: no changes were needed.",
+            input.instruction,
+          ),
+        );
         await this.dependencies.logStore.write(
           input.task.taskId,
           "mutate completed with no changes",
@@ -267,39 +282,80 @@ export class ExecutionService {
         return { status: "succeeded" };
       }
 
-      await this.dependencies.workspaceManager.commitAll(
-        workspace,
-        this.buildCommitMessage(input.task),
-      );
-      const mutateToken =
-        await this.dependencies.githubClient.getInstallationAccessToken(
-          input.task.repo,
+      try {
+        await this.dependencies.workspaceManager.commitAll(
+          workspace,
+          this.buildCommitMessage(input.task),
         );
-      await this.dependencies.workspaceManager.pushBranch(workspace, {
-        installationToken: mutateToken,
-      });
+        const mutateToken =
+          await this.dependencies.githubClient.getInstallationAccessToken(
+            input.task.repo,
+          );
+        await this.dependencies.workspaceManager.pushBranch(workspace, {
+          installationToken: mutateToken,
+        });
 
-      const prBody = this.withInstructionFooter(
-        agentResult.stdout.trim(),
-        input.instruction,
-      );
-      const prTitle = this.buildPullRequestTitle(input.task);
-      const pullRequest = await this.resultWriter.writeMutateResult({
-        task: input.task,
-        instruction: input.instruction,
-        baseBranch,
-        branchName: workspace.branchName,
-        title: prTitle,
-        body: prBody,
-      });
+        const prBody = this.withInstructionFooter(
+          agentResult.stdout.trim(),
+          input.instruction,
+        );
+        const prTitle = this.buildPullRequestTitle(input.task);
+        const pullRequest = await this.resultWriter.writeMutateResult({
+          task: input.task,
+          instruction: input.instruction,
+          baseBranch,
+          branchName: workspace.branchName,
+          title: prTitle,
+          body: prBody,
+        });
 
-      await this.dependencies.logStore.write(
-        input.task.taskId,
-        `mutate completed with PR ${pullRequest.url}`,
-      );
-      return { status: "succeeded" };
+        await this.dependencies.logStore.write(
+          input.task.taskId,
+          `mutate completed with PR ${pullRequest.url}`,
+        );
+        return { status: "succeeded" };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "mutate publish failed";
+        await this.postSourceComment(
+          input,
+          this.withInstructionFooter(
+            `Ran \`/claude implement\`: failed to publish result.\n\n${truncate(message, 1500)}`,
+            input.instruction,
+          ),
+        );
+        return this.fail(input.task.taskId, message);
+      }
     } finally {
       await this.dependencies.workspaceManager.cleanupWorkspace(workspace);
+    }
+  }
+
+  private async postSourceComment(
+    input: ExecuteTaskInput,
+    body: string,
+  ): Promise<void> {
+    try {
+      if (input.task.source.kind === "issue") {
+        await this.dependencies.githubClient.postIssueComment(
+          input.task.repo,
+          input.task.source.number,
+          body,
+        );
+      } else {
+        await this.dependencies.githubClient.postPullRequestComment(
+          input.task.repo,
+          input.task.source.number,
+          body,
+        );
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      await this.dependencies.logStore.write(
+        input.task.taskId,
+        `failed to post fallback comment: ${message}`,
+      );
     }
   }
 
@@ -335,4 +391,12 @@ export class ExecutionService {
 
     return `Follow up for PR #${task.source.number}`;
   }
+}
+
+function truncate(text: string, maxLength: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, maxLength)}\n…(truncated, original ${trimmed.length} bytes)`;
 }

--- a/tests/unit/execution-service.test.ts
+++ b/tests/unit/execution-service.test.ts
@@ -589,7 +589,9 @@ describe("ExecutionService", () => {
     assert.match(postedComments[0] ?? "", /https:\/\/example\.test\/pr\/15/);
   });
 
-  test("marks mutate work as succeeded without PR when no diff exists", async () => {
+  test("marks mutate work as succeeded without PR and posts a no-op comment when no diff exists", async () => {
+    const postedComments: string[] = [];
+
     const service = new ExecutionService({
       githubClient: {
         getSourceContext: async () => issueContext,
@@ -608,7 +610,9 @@ describe("ExecutionService", () => {
           slug: "bot",
         }),
         getInstallationAccessToken: async () => "test-token",
-        postIssueComment: async () => {},
+        postIssueComment: async (_repo, _number, body) => {
+          postedComments.push(body);
+        },
         postPullRequestComment: async () => {},
         findOpenPullRequestByBranch: async () => null,
         createPullRequest: async () => {
@@ -663,6 +667,168 @@ describe("ExecutionService", () => {
     });
 
     assert.equal(result.status, "succeeded");
+    assert.equal(postedComments.length, 1);
+    assert.match(postedComments[0] ?? "", /no changes were needed/);
+  });
+
+  test("mutate posts a fallback comment and fails when the agent exits non-zero", async () => {
+    const postedComments: string[] = [];
+
+    const service = new ExecutionService({
+      githubClient: {
+        getSourceContext: async () => issueContext,
+        getDefaultBranch: async () => "main",
+        getPullRequestState: async () => ({
+          number: 0,
+          isFork: false,
+          state: "open" as const,
+          merged: false,
+          headRef: "feature/x",
+        }),
+        getIssueLabels: async () => ({ labels: [] }),
+        getAppBotInfo: async () => ({
+          id: 1,
+          login: "bot[bot]",
+          slug: "bot",
+        }),
+        getInstallationAccessToken: async () => "test-token",
+        postIssueComment: async (_repo, _number, body) => {
+          postedComments.push(body);
+        },
+        postPullRequestComment: async () => {},
+        findOpenPullRequestByBranch: async () => null,
+        createPullRequest: async () => {
+          throw new Error("should not create a PR");
+        },
+        updatePullRequest: async () => {
+          throw new Error("should not update a PR");
+        },
+      },
+      workspaceManager: {
+        prepareObserveWorkspace: async () => ({ workspacePath: "/tmp/observe" }),
+        prepareMutateWorkspace: async () => ({
+          workspacePath: "/tmp/mutate",
+          branchName: "ai/issue-100",
+        }),
+        preparePrImplementWorkspace: async () => ({
+          workspacePath: "/tmp/pr-implement",
+          branchName: "feature/x",
+        }),
+        hasChanges: async () => false,
+        commitAll: async () => {
+          throw new Error("must not commit when agent failed");
+        },
+        pushBranch: async () => {
+          throw new Error("must not push when agent failed");
+        },
+        cleanupWorkspace: async () => {},
+      },
+      agentRegistry: {
+        resolve: () => ({
+          run: async () => ({
+            exitCode: 2,
+            stdout: "",
+            stderr: "boom: something blew up",
+          }),
+        }),
+      },
+      logStore: {
+        write: async () => {},
+        cleanupExpired: async () => {},
+      },
+      queueStore: {
+        listTasks: async () => [],
+      },
+    });
+
+    const result = await service.execute({
+      task: createTask("issue-implement"),
+      instruction: mutateInstruction,
+    });
+
+    assert.equal(result.status, "failed");
+    assert.equal(postedComments.length, 1);
+    assert.match(postedComments[0] ?? "", /agent exited with code 2/);
+    assert.match(postedComments[0] ?? "", /boom: something blew up/);
+  });
+
+  test("mutate posts a fallback comment and fails when push throws", async () => {
+    const postedComments: string[] = [];
+
+    const service = new ExecutionService({
+      githubClient: {
+        getSourceContext: async () => issueContext,
+        getDefaultBranch: async () => "main",
+        getPullRequestState: async () => ({
+          number: 0,
+          isFork: false,
+          state: "open" as const,
+          merged: false,
+          headRef: "feature/x",
+        }),
+        getIssueLabels: async () => ({ labels: [] }),
+        getAppBotInfo: async () => ({
+          id: 1,
+          login: "bot[bot]",
+          slug: "bot",
+        }),
+        getInstallationAccessToken: async () => "test-token",
+        postIssueComment: async (_repo, _number, body) => {
+          postedComments.push(body);
+        },
+        postPullRequestComment: async () => {},
+        findOpenPullRequestByBranch: async () => null,
+        createPullRequest: async () => {
+          throw new Error("must not create a PR when push failed");
+        },
+        updatePullRequest: async () => {
+          throw new Error("must not update a PR when push failed");
+        },
+      },
+      workspaceManager: {
+        prepareObserveWorkspace: async () => ({ workspacePath: "/tmp/observe" }),
+        prepareMutateWorkspace: async () => ({
+          workspacePath: "/tmp/mutate",
+          branchName: "ai/issue-100",
+        }),
+        preparePrImplementWorkspace: async () => ({
+          workspacePath: "/tmp/pr-implement",
+          branchName: "feature/x",
+        }),
+        hasChanges: async () => true,
+        commitAll: async () => {},
+        pushBranch: async () => {
+          throw new Error("non-fast-forward push rejected");
+        },
+        cleanupWorkspace: async () => {},
+      },
+      agentRegistry: {
+        resolve: () => ({
+          run: async () => ({
+            exitCode: 0,
+            stdout: "Implemented",
+            stderr: "",
+          }),
+        }),
+      },
+      logStore: {
+        write: async () => {},
+        cleanupExpired: async () => {},
+      },
+      queueStore: {
+        listTasks: async () => [],
+      },
+    });
+
+    const result = await service.execute({
+      task: createTask("issue-implement"),
+      instruction: mutateInstruction,
+    });
+
+    assert.equal(result.status, "failed");
+    assert.equal(postedComments.length, 1);
+    assert.match(postedComments[0] ?? "", /failed to publish result/);
+    assert.match(postedComments[0] ?? "", /non-fast-forward/);
   });
 
   test("pr-implement pushes commits to PR head and posts a status comment without creating a new PR", async () => {


### PR DESCRIPTION
## Summary
- Three previously silent branches in `executeMutate` (agent exit != 0, no-changes, commit/push/writeMutateResult throw) now post a short comment to the originating issue / PR before returning.
- New `postSourceComment` helper picks the right `postIssueComment` / `postPullRequestComment` based on `task.source.kind`; new `truncate` helper caps quoted stderr at 1500 chars with a tail marker.
- Tests cover all three new branches plus the no-changes case now asserts the comment.

## Test plan
- [x] `npm test` (132 tests pass)

Resolves #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)