### PR TITLE
feat(daemon): notifyTaskFailure callback for catch-all failures

### DIFF
--- a/src/daemon/runner-daemon.ts
+++ b/src/daemon/runner-daemon.ts
@@ -20,6 +20,10 @@ export interface RunnerDaemonDependencies {
   idleWarningIntervalMs?: number;
   now?: () => number;
   warn?: (message: string) => void;
+  notifyTaskFailure?: (
+    task: TaskRecord,
+    errorSummary: string,
+  ) => Promise<void>;
 }
 
 const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 60 * 60 * 1000;
@@ -177,6 +181,21 @@ export class RunnerDaemon {
       console.error(
         `[daemon] fail task=${task.taskId} error=${result.errorSummary ?? "unknown"}`,
       );
+
+      if (this.dependencies.notifyTaskFailure !== undefined) {
+        try {
+          await this.dependencies.notifyTaskFailure(
+            task,
+            result.errorSummary ?? "unknown",
+          );
+        } catch (error) {
+          this.warn(
+            `[daemon] notifyTaskFailure threw: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
     }
 
     await this.dependencies.queueStore.completeTask(task.taskId, result);

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,30 @@ export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
     rateLimitStateStore,
     rateLimitCooldownMs,
     registeredAgents: agentConfig.agents,
+    notifyTaskFailure: async (task, errorSummary) => {
+      const body = `Task \`${task.taskId}\` failed before completion: ${errorSummary}`;
+      try {
+        if (task.source.kind === "issue") {
+          await githubClient.postIssueComment(
+            task.repo,
+            task.source.number,
+            body,
+          );
+        } else {
+          await githubClient.postPullRequestComment(
+            task.repo,
+            task.source.number,
+            body,
+          );
+        }
+      } catch (error) {
+        console.warn(
+          `[daemon] failed to post failure comment for task=${task.taskId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    },
   });
 
   const repoAllowlist = RepoAllowlist.fromEnv(process.env.ALLOWED_REPOS);

--- a/tests/unit/runner-daemon.test.ts
+++ b/tests/unit/runner-daemon.test.ts
@@ -177,4 +177,173 @@ describe("RunnerDaemon", () => {
     assert.ok(calls.includes("revert:task_1"));
     assert.ok(calls.some((c) => c.startsWith("log:task_1:rate-limited")));
   });
+
+  test("notifies task failure when execution throws a non rate-limit error", async () => {
+    const notified: Array<{ taskId: string; errorSummary: string }> = [];
+    let currentTask = createTask("queued");
+
+    const daemon = new RunnerDaemon({
+      queueStore: {
+        enqueue: async () => currentTask,
+        listTasks: async () => [currentTask],
+        getTask: async () => currentTask,
+        startTask: async (_taskId, instructionRevision) => {
+          currentTask = {
+            ...currentTask,
+            status: "running",
+            instructionRevision,
+            startedAt: "2026-04-27T00:01:00.000Z",
+          };
+          return currentTask;
+        },
+        completeTask: async (_taskId, input) => {
+          currentTask = {
+            ...currentTask,
+            status: input.status,
+            ...(input.errorSummary !== undefined
+              ? { errorSummary: input.errorSummary }
+              : {}),
+          };
+          return currentTask;
+        },
+        revertToQueued: async () => currentTask,
+        recoverRunningTasks: async () => {},
+      },
+      instructionLoader: {
+        loadById: async () => instruction,
+      },
+      schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      executionService: {
+        execute: async () => {
+          throw new Error("getSourceContext network failure");
+        },
+      },
+      logStore: {
+        write: async () => {},
+        cleanupExpired: async () => {},
+      },
+      pollIntervalMs: 10,
+      notifyTaskFailure: async (task, errorSummary) => {
+        notified.push({ taskId: task.taskId, errorSummary });
+      },
+    });
+
+    await daemon.tick();
+    await daemon.waitForIdle();
+
+    assert.equal(notified.length, 1);
+    assert.equal(notified[0]?.taskId, "task_1");
+    assert.match(notified[0]?.errorSummary ?? "", /getSourceContext/);
+  });
+
+  test("does not notify task failure on RateLimitedError", async () => {
+    const notified: string[] = [];
+    let currentTask = createTask("queued");
+
+    const daemon = new RunnerDaemon({
+      queueStore: {
+        enqueue: async () => currentTask,
+        listTasks: async () => [currentTask],
+        getTask: async () => currentTask,
+        startTask: async (_taskId, instructionRevision) => {
+          currentTask = {
+            ...currentTask,
+            status: "running",
+            instructionRevision,
+            startedAt: "2026-04-27T00:01:00.000Z",
+          };
+          return currentTask;
+        },
+        completeTask: async () => {
+          throw new Error("completeTask should not run for rate-limited tasks");
+        },
+        revertToQueued: async () => currentTask,
+        recoverRunningTasks: async () => {},
+      },
+      instructionLoader: {
+        loadById: async () => instruction,
+      },
+      schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      executionService: {
+        execute: async () => {
+          throw new RateLimitedError("claude");
+        },
+      },
+      logStore: {
+        write: async () => {},
+        cleanupExpired: async () => {},
+      },
+      pollIntervalMs: 10,
+      notifyTaskFailure: async (task) => {
+        notified.push(task.taskId);
+      },
+    });
+
+    await daemon.tick();
+    await daemon.waitForIdle();
+
+    assert.equal(notified.length, 0);
+  });
+
+  test("daemon survives when notifyTaskFailure throws", async () => {
+    const warnings: string[] = [];
+    let currentTask = createTask("queued");
+
+    const daemon = new RunnerDaemon({
+      queueStore: {
+        enqueue: async () => currentTask,
+        listTasks: async () => [currentTask],
+        getTask: async () => currentTask,
+        startTask: async (_taskId, instructionRevision) => {
+          currentTask = {
+            ...currentTask,
+            status: "running",
+            instructionRevision,
+            startedAt: "2026-04-27T00:01:00.000Z",
+          };
+          return currentTask;
+        },
+        completeTask: async (_taskId, input) => {
+          currentTask = {
+            ...currentTask,
+            status: input.status,
+            ...(input.errorSummary !== undefined
+              ? { errorSummary: input.errorSummary }
+              : {}),
+          };
+          return currentTask;
+        },
+        revertToQueued: async () => currentTask,
+        recoverRunningTasks: async () => {},
+      },
+      instructionLoader: {
+        loadById: async () => instruction,
+      },
+      schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      executionService: {
+        execute: async () => ({
+          status: "failed",
+          errorSummary: "boom",
+        }),
+      },
+      logStore: {
+        write: async () => {},
+        cleanupExpired: async () => {},
+      },
+      pollIntervalMs: 10,
+      warn: (message) => warnings.push(message),
+      notifyTaskFailure: async () => {
+        throw new Error("notify failed");
+      },
+    });
+
+    await daemon.tick();
+    await daemon.waitForIdle();
+
+    assert.equal(currentTask.status, "failed");
+    assert.ok(
+      warnings.some((message) => message.includes("notifyTaskFailure threw")),
+      `expected a warning about notifyTaskFailure, got: ${warnings.join(", ")}`,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Add optional `notifyTaskFailure` callback on `RunnerDaemonDependencies`. The daemon invokes it whenever `runTask`'s execute call yields a `failed` result (including thrown errors that are not `RateLimitedError`).
- Wire `src/index.ts` to provide a callback that posts a short comment to the originating issue / PR via `githubClient`.
- Tests: callback fires on a thrown non-rate-limit error, does NOT fire on `RateLimitedError`, and the daemon survives a callback that itself throws (warn-only).

## Test plan
- [x] `npm test` (135 tests pass)

Resolves #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)