### PR TITLE
feat(prompt): expand Mode line into a Policy block

### DIFF
--- a/src/services/execution/execution-prompt-builder.ts
+++ b/src/services/execution/execution-prompt-builder.ts
@@ -1,5 +1,8 @@
 import type { GitHubComment, GitHubSourceContext } from "../../domain/github.js";
-import type { InstructionDefinition } from "../../domain/instruction.js";
+import type {
+  ExecutionMode,
+  InstructionDefinition,
+} from "../../domain/instruction.js";
 import type { TaskRecord } from "../../domain/task.js";
 
 export interface BuildExecutionPromptInput {
@@ -13,7 +16,8 @@ export class ExecutionPromptBuilder {
     const { context, instruction, task } = input;
     const lines = [
       `Instruction: ${instruction.id}`,
-      `Mode: ${instruction.mode}`,
+      "Policy:",
+      ...this.buildPolicyLines(instruction.mode),
       `Repository: ${task.repo.owner}/${task.repo.name}`,
       `Source: ${task.source.kind} #${task.source.number}`,
       `Title: ${context.title}`,
@@ -47,6 +51,25 @@ export class ExecutionPromptBuilder {
     lines.push("", `Base: ${context.baseRef}`, `Head: ${context.headRef}`);
     this.appendAdditionalInstructions(lines, task.additionalInstructions);
     return lines.join("\n");
+  }
+
+  private buildPolicyLines(mode: ExecutionMode): string[] {
+    if (mode === "observe") {
+      return [
+        "- Mode: observe",
+        "- You may read files in the workspace.",
+        "- You may call GitHub APIs via `gh` (issue/PR/comment read AND write, cross-repo issue lookup).",
+        "- You MUST NOT modify files in the workspace, run `git add`, `git commit`, or `git push`.",
+        "- Use the workspace clone only as a read-only reference.",
+      ];
+    }
+
+    return [
+      "- Mode: mutate",
+      "- You may read and write files in the workspace.",
+      "- You may run `git add`, `git commit`. The runner pushes for you.",
+      "- You may call GitHub APIs via `gh` for read-only context. The runner publishes the PR.",
+    ];
   }
 
   private appendAdditionalInstructions(

--- a/tests/unit/execution-prompt-builder.test.ts
+++ b/tests/unit/execution-prompt-builder.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { GitHubSourceContext } from "../../src/domain/github.js";
+import type { InstructionDefinition } from "../../src/domain/instruction.js";
+import type { TaskRecord } from "../../src/domain/task.js";
+import { ExecutionPromptBuilder } from "../../src/services/execution/execution-prompt-builder.js";
+
+const baseTask: TaskRecord = {
+  taskId: "task_1",
+  repo: { owner: "octo", name: "repo" },
+  source: { kind: "issue", number: 100 },
+  instructionId: "issue-comment-reply",
+  agent: "claude",
+  status: "running",
+  priority: "normal",
+  requestedBy: "test",
+  createdAt: "2026-04-27T00:00:00.000Z",
+  startedAt: "2026-04-27T00:01:00.000Z",
+};
+
+const issueContext: GitHubSourceContext = {
+  kind: "issue",
+  title: "Title",
+  body: "Body",
+  comments: [],
+};
+
+const observeInstruction: InstructionDefinition = {
+  id: "issue-comment-reply",
+  revision: 1,
+  sourceKind: "issue",
+  mode: "observe",
+  context: {},
+  permissions: {
+    codeRead: true,
+    codeWrite: false,
+    gitPush: false,
+    prCreate: false,
+    prUpdate: false,
+    commentWrite: true,
+  },
+  githubActions: ["issue_comment"],
+  execution: {
+    timeoutSec: 1800,
+  },
+};
+
+const mutateInstruction: InstructionDefinition = {
+  ...observeInstruction,
+  id: "issue-implement",
+  mode: "mutate",
+  permissions: {
+    codeRead: true,
+    codeWrite: true,
+    gitPush: true,
+    prCreate: true,
+    prUpdate: true,
+    commentWrite: true,
+  },
+};
+
+describe("ExecutionPromptBuilder", () => {
+  test("observe prompts contain a Policy block forbidding workspace writes", () => {
+    const prompt = new ExecutionPromptBuilder().build({
+      task: baseTask,
+      instruction: observeInstruction,
+      context: issueContext,
+    });
+
+    assert.match(prompt, /Policy:/);
+    assert.match(prompt, /- Mode: observe/);
+    assert.match(prompt, /MUST NOT modify files/);
+    assert.match(prompt, /git push/);
+    assert.match(prompt, /gh/);
+  });
+
+  test("mutate prompts contain a Policy block allowing edits but no push", () => {
+    const prompt = new ExecutionPromptBuilder().build({
+      task: baseTask,
+      instruction: mutateInstruction,
+      context: issueContext,
+    });
+
+    assert.match(prompt, /Policy:/);
+    assert.match(prompt, /- Mode: mutate/);
+    assert.match(prompt, /read and write files/);
+    assert.match(prompt, /runner pushes for you/);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the single-line `Mode: observe` / `Mode: mutate` in the agent prompt with an explicit `Policy:` block that spells out what is allowed (workspace IO, `gh` API writes, `git commit`) and what is forbidden in each mode.
- Adds `buildPolicyLines(mode)` to `ExecutionPromptBuilder` and a new `tests/unit/execution-prompt-builder.test.ts` covering both modes.

## Test plan
- [x] `npm test` (135 tests pass)

Resolves #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)