### PR TITLE
feat(agent): forward installation token to agent env

### DIFF
--- a/src/domain/agent.ts
+++ b/src/domain/agent.ts
@@ -6,6 +6,7 @@ export interface AgentRunInput {
   instruction: InstructionDefinition;
   workspacePath: string;
   prompt: string;
+  installationToken?: string;
 }
 
 export interface AgentRunResult {

--- a/src/infra/agent/headless-command-agent-runner.ts
+++ b/src/infra/agent/headless-command-agent-runner.ts
@@ -27,6 +27,12 @@ export class HeadlessCommandAgentRunner implements AgentRunner {
         RUNNER_INSTRUCTION_ID: input.instruction.id,
         RUNNER_REPO_OWNER: input.task.repo.owner,
         RUNNER_REPO_NAME: input.task.repo.name,
+        ...(input.installationToken !== undefined
+          ? {
+              GH_TOKEN: input.installationToken,
+              GITHUB_TOKEN: input.installationToken,
+            }
+          : {}),
       },
     });
 

--- a/src/infra/workspaces/secret-mask.ts
+++ b/src/infra/workspaces/secret-mask.ts
@@ -1,6 +1,9 @@
 const PATTERNS: Array<[RegExp, string]> = [
   [/AUTHORIZATION:\s*Basic\s+\S+/gi, "AUTHORIZATION: Basic ***"],
   [/x-access-token:[^@\s'"]+/g, "x-access-token:***"],
+  [/ghs_[A-Za-z0-9]{20,}/g, "ghs_***"],
+  [/ghu_[A-Za-z0-9]{20,}/g, "ghu_***"],
+  [/gho_[A-Za-z0-9]{20,}/g, "gho_***"],
 ];
 
 export function maskSecrets(input: string): string {

--- a/src/services/execution-service.ts
+++ b/src/services/execution-service.ts
@@ -92,6 +92,7 @@ export class ExecutionService {
           task: input.task,
           instruction: input.instruction,
           workspacePath: workspace.workspacePath,
+          installationToken,
           prompt: this.promptBuilder.build({
             task: input.task,
             instruction: input.instruction,
@@ -192,6 +193,7 @@ export class ExecutionService {
           task: input.task,
           instruction: input.instruction,
           workspacePath: workspace.workspacePath,
+          installationToken,
           prompt: this.promptBuilder.build({
             task: input.task,
             instruction: input.instruction,
@@ -260,6 +262,7 @@ export class ExecutionService {
           task: input.task,
           instruction: input.instruction,
           workspacePath: workspace.workspacePath,
+          installationToken,
           prompt: this.promptBuilder.build({
             task: input.task,
             instruction: input.instruction,

--- a/tests/unit/execution-service.test.ts
+++ b/tests/unit/execution-service.test.ts
@@ -232,6 +232,86 @@ describe("ExecutionService", () => {
     assert.doesNotMatch(prompts[0]?.prompt ?? "", /Comments:/);
   });
 
+  test("forwards the installation token to the agent runner", async () => {
+    const runInputs: AgentRunInput[] = [];
+
+    const service = new ExecutionService({
+      githubClient: {
+        getSourceContext: async () => issueContext,
+        getDefaultBranch: async () => "main",
+        getPullRequestState: async () => ({
+          number: 0,
+          isFork: false,
+          state: "open" as const,
+          merged: false,
+          headRef: "feature/x",
+        }),
+        getIssueLabels: async () => ({ labels: [] }),
+        getAppBotInfo: async () => ({
+          id: 1,
+          login: "bot[bot]",
+          slug: "bot",
+        }),
+        getInstallationAccessToken: async () => "ghs_TEST_TOKEN",
+        postIssueComment: async () => {},
+        postPullRequestComment: async () => {},
+        findOpenPullRequestByBranch: async () => null,
+        createPullRequest: async () => ({
+          number: 1,
+          url: "https://example.test/pr/1",
+          branchName: "ai/issue-100",
+        }),
+        updatePullRequest: async () => ({
+          number: 1,
+          url: "https://example.test/pr/1",
+          branchName: "ai/issue-100",
+        }),
+      },
+      workspaceManager: {
+        prepareObserveWorkspace: async () => ({ workspacePath: "/tmp/observe" }),
+        prepareMutateWorkspace: async () => ({
+          workspacePath: "/tmp/mutate",
+          branchName: "ai/issue-100",
+        }),
+        preparePrImplementWorkspace: async () => ({
+          workspacePath: "/tmp/pr-implement",
+          branchName: "feature/x",
+        }),
+        hasChanges: async () => false,
+        commitAll: async () => {},
+        pushBranch: async () => {},
+        cleanupWorkspace: async () => {},
+      },
+      agentRegistry: {
+        resolve: () => ({
+          run: async (input: AgentRunInput): Promise<AgentRunResult> => {
+            runInputs.push(input);
+            return {
+              exitCode: 0,
+              stdout: "Observed",
+              stderr: "",
+            };
+          },
+        }),
+      },
+      logStore: {
+        write: async () => {},
+        cleanupExpired: async () => {},
+      },
+      queueStore: {
+        listTasks: async () => [],
+      },
+    });
+
+    const result = await service.execute({
+      task: createTask("issue-comment-reply"),
+      instruction: observeInstruction,
+    });
+
+    assert.equal(result.status, "succeeded");
+    assert.equal(runInputs[0]?.installationToken, "ghs_TEST_TOKEN");
+  });
+
   test("runs observe work and posts an issue comment", async () => {
     const postedComments: string[] = [];
     const prompts: AgentRunInput[] = [];

--- a/tests/unit/headless-command-agent-runner.test.ts
+++ b/tests/unit/headless-command-agent-runner.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { AgentRunInput } from "../../src/domain/agent.js";
+import type { InstructionDefinition } from "../../src/domain/instruction.js";
+import type { TaskRecord } from "../../src/domain/task.js";
+import { HeadlessCommandAgentRunner } from "../../src/infra/agent/headless-command-agent-runner.js";
+import type {
+  ProcessRunner,
+  RunProcessInput,
+  RunProcessResult,
+} from "../../src/infra/platform/process-runner.js";
+
+const instruction: InstructionDefinition = {
+  id: "issue-comment-reply",
+  revision: 1,
+  sourceKind: "issue",
+  mode: "observe",
+  context: {},
+  permissions: {
+    codeRead: true,
+    codeWrite: false,
+    gitPush: false,
+    prCreate: false,
+    prUpdate: false,
+    commentWrite: true,
+  },
+  githubActions: ["issue_comment"],
+  execution: {
+    timeoutSec: 60,
+  },
+};
+
+const task: TaskRecord = {
+  taskId: "task_1",
+  repo: { owner: "octo", name: "repo" },
+  source: { kind: "issue", number: 100 },
+  instructionId: "issue-comment-reply",
+  agent: "claude",
+  status: "running",
+  priority: "normal",
+  requestedBy: "test",
+  createdAt: "2026-04-27T00:00:00.000Z",
+  startedAt: "2026-04-27T00:01:00.000Z",
+};
+
+function createRunner(): { processRunner: ProcessRunner; calls: RunProcessInput[] } {
+  const calls: RunProcessInput[] = [];
+  const processRunner: ProcessRunner = {
+    run: async (input): Promise<RunProcessResult> => {
+      calls.push(input);
+      return { exitCode: 0, stdout: "ok", stderr: "" };
+    },
+  };
+  return { processRunner, calls };
+}
+
+describe("HeadlessCommandAgentRunner env wiring", () => {
+  test("sets GH_TOKEN and GITHUB_TOKEN when an installation token is provided", async () => {
+    const { processRunner, calls } = createRunner();
+    const runner = new HeadlessCommandAgentRunner({
+      command: "claude",
+      processRunner,
+    });
+
+    const runInput: AgentRunInput = {
+      task,
+      instruction,
+      workspacePath: "/tmp/ws",
+      prompt: "hello",
+      installationToken: "ghs_FAKE_TOKEN",
+    };
+
+    await runner.run(runInput);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.env?.GH_TOKEN, "ghs_FAKE_TOKEN");
+    assert.equal(calls[0]?.env?.GITHUB_TOKEN, "ghs_FAKE_TOKEN");
+  });
+
+  test("does not set GH_TOKEN/GITHUB_TOKEN when no installation token is provided", async () => {
+    const { processRunner, calls } = createRunner();
+    const previousGh = process.env.GH_TOKEN;
+    const previousGithub = process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+
+    try {
+      const runner = new HeadlessCommandAgentRunner({
+        command: "claude",
+        processRunner,
+      });
+
+      await runner.run({
+        task,
+        instruction,
+        workspacePath: "/tmp/ws",
+        prompt: "hello",
+      });
+
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0]?.env?.GH_TOKEN, undefined);
+      assert.equal(calls[0]?.env?.GITHUB_TOKEN, undefined);
+    } finally {
+      if (previousGh !== undefined) process.env.GH_TOKEN = previousGh;
+      if (previousGithub !== undefined) process.env.GITHUB_TOKEN = previousGithub;
+    }
+  });
+});

--- a/tests/unit/secret-mask.test.ts
+++ b/tests/unit/secret-mask.test.ts
@@ -38,4 +38,19 @@ describe("maskSecrets", () => {
     const input = "git push origin feature/x";
     assert.equal(maskSecrets(input), input);
   });
+
+  test("masks bare ghs_ installation tokens", () => {
+    const input = "GH_TOKEN=ghs_AbCdE12345abcdeABCDE6789xyz";
+    assert.equal(maskSecrets(input), "GH_TOKEN=ghs_***");
+  });
+
+  test("masks ghu_ user tokens", () => {
+    const input = "header: ghu_AbCdE12345abcdeABCDE6789xyz";
+    assert.equal(maskSecrets(input), "header: ghu_***");
+  });
+
+  test("masks gho_ oauth tokens", () => {
+    const input = "x-token=gho_AbCdE12345abcdeABCDE6789xyz tail";
+    assert.equal(maskSecrets(input), "x-token=gho_*** tail");
+  });
 });


### PR DESCRIPTION
## Summary
- Add optional `installationToken` to `AgentRunInput`. The headless runner forwards it as `GH_TOKEN` and `GITHUB_TOKEN` so the embedded `gh` CLI authenticates without the runner having to fetch a separate user token.
- Wire `execution-service` to forward the installation token already in hand for observe / mutate / pr-implement.
- Extend `secret-mask` with `ghs_*`, `ghu_*`, `gho_*` patterns so masked logs do not leak the token.

## Test plan
- [x] `npm test` (141 tests pass)

Resolves #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)