### PR TITLE
feat(agent): mode-aware --allowed-tools / --disallowed-tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { ChildProcessRunner } from "./infra/platform/process-runner.js";
 import { HeadlessCommandAgentRunner } from "./infra/agent/headless-command-agent-runner.js";
 import { RateLimitDetectingAgentRunner } from "./infra/agent/rate-limit-detecting-agent-runner.js";
 import { loadAgentRateLimitConfig } from "./infra/agent/agent-rate-limit-config.js";
+import { buildClaudeToolArgs } from "./infra/agent/agent-tool-policies.js";
 import { GitWorkspaceManager } from "./infra/workspaces/git-workspace-manager.js";
 import { GitHubAppClient } from "./infra/github/github-app-client.js";
 import {
@@ -99,6 +100,7 @@ export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
         command: agentConfig.commands[name]!.command,
         args: agentConfig.commands[name]!.args,
         processRunner,
+        ...(name === "claude" ? { modeArgsBuilder: buildClaudeToolArgs } : {}),
       });
 
       return {

--- a/src/infra/agent/agent-tool-policies.ts
+++ b/src/infra/agent/agent-tool-policies.ts
@@ -1,0 +1,19 @@
+import type { ExecutionMode } from "../../domain/instruction.js";
+
+export function buildClaudeToolArgs(mode: ExecutionMode): string[] {
+  if (mode === "observe") {
+    return [
+      "--allowed-tools",
+      "Read Grep Glob Bash(gh:*) Bash(git log:*) Bash(git diff:*) Bash(git status:*) Bash(git show:*)",
+      "--disallowed-tools",
+      "Edit Write MultiEdit NotebookEdit Bash(git push:*) Bash(git commit:*) Bash(git add:*) Bash(rm:*) Bash(mv:*)",
+    ];
+  }
+
+  return [
+    "--allowed-tools",
+    "Read Grep Glob Edit Write MultiEdit Bash(gh:*) Bash(git:*) Bash(npm:*) Bash(node:*)",
+    "--disallowed-tools",
+    "Bash(git push:*)",
+  ];
+}

--- a/src/infra/agent/headless-command-agent-runner.ts
+++ b/src/infra/agent/headless-command-agent-runner.ts
@@ -1,4 +1,5 @@
 import type { AgentRunInput, AgentRunResult } from "../../domain/agent.js";
+import type { ExecutionMode } from "../../domain/instruction.js";
 import type { AgentRunner } from "./agent-runner.js";
 import type { ProcessRunner } from "../platform/process-runner.js";
 
@@ -7,15 +8,22 @@ export interface HeadlessCommandAgentRunnerOptions {
   args?: string[];
   processRunner: ProcessRunner;
   extraEnv?: NodeJS.ProcessEnv;
+  modeArgsBuilder?: (mode: ExecutionMode) => string[];
 }
 
 export class HeadlessCommandAgentRunner implements AgentRunner {
   constructor(private readonly options: HeadlessCommandAgentRunnerOptions) {}
 
   async run(input: AgentRunInput): Promise<AgentRunResult> {
+    const baseArgs = this.options.args ?? [];
+    const modeArgs =
+      this.options.modeArgsBuilder !== undefined
+        ? this.options.modeArgsBuilder(input.instruction.mode)
+        : [];
+
     const result = await this.options.processRunner.run({
       command: this.options.command,
-      args: this.options.args ?? [],
+      args: [...baseArgs, ...modeArgs],
       cwd: input.workspacePath,
       stdin: input.prompt,
       timeoutMs: input.instruction.execution.timeoutSec * 1000,

--- a/tests/unit/agent-tool-policies.test.ts
+++ b/tests/unit/agent-tool-policies.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { buildClaudeToolArgs } from "../../src/infra/agent/agent-tool-policies.js";
+
+describe("buildClaudeToolArgs", () => {
+  test("observe mode allows read/grep/gh and disallows file-mutating tools", () => {
+    const args = buildClaudeToolArgs("observe");
+
+    const allowedIdx = args.indexOf("--allowed-tools");
+    const disallowedIdx = args.indexOf("--disallowed-tools");
+
+    assert.ok(allowedIdx >= 0);
+    assert.ok(disallowedIdx >= 0);
+
+    const allowed = args[allowedIdx + 1] ?? "";
+    const disallowed = args[disallowedIdx + 1] ?? "";
+
+    assert.match(allowed, /Read/);
+    assert.match(allowed, /Grep/);
+    assert.match(allowed, /Bash\(gh:\*\)/);
+    assert.match(allowed, /Bash\(git log:\*\)/);
+
+    assert.match(disallowed, /\bEdit\b/);
+    assert.match(disallowed, /\bWrite\b/);
+    assert.match(disallowed, /Bash\(git push:\*\)/);
+    assert.match(disallowed, /Bash\(git commit:\*\)/);
+    assert.match(disallowed, /Bash\(git add:\*\)/);
+  });
+
+  test("mutate mode allows edits and gh/git but disallows git push", () => {
+    const args = buildClaudeToolArgs("mutate");
+
+    const allowedIdx = args.indexOf("--allowed-tools");
+    const disallowedIdx = args.indexOf("--disallowed-tools");
+
+    assert.ok(allowedIdx >= 0);
+    assert.ok(disallowedIdx >= 0);
+
+    const allowed = args[allowedIdx + 1] ?? "";
+    const disallowed = args[disallowedIdx + 1] ?? "";
+
+    assert.match(allowed, /\bEdit\b/);
+    assert.match(allowed, /\bWrite\b/);
+    assert.match(allowed, /Bash\(gh:\*\)/);
+    assert.match(allowed, /Bash\(git:\*\)/);
+
+    assert.match(disallowed, /Bash\(git push:\*\)/);
+  });
+});

--- a/tests/unit/headless-command-agent-runner.test.ts
+++ b/tests/unit/headless-command-agent-runner.test.ts
@@ -77,6 +77,32 @@ describe("HeadlessCommandAgentRunner env wiring", () => {
     assert.equal(calls[0]?.env?.GITHUB_TOKEN, "ghs_FAKE_TOKEN");
   });
 
+  test("modeArgsBuilder output is appended to base args", async () => {
+    const { processRunner, calls } = createRunner();
+    const runner = new HeadlessCommandAgentRunner({
+      command: "claude",
+      args: ["--print"],
+      processRunner,
+      modeArgsBuilder: (mode) =>
+        mode === "observe"
+          ? ["--allowed-tools", "Read"]
+          : ["--allowed-tools", "Edit"],
+    });
+
+    await runner.run({
+      task,
+      instruction,
+      workspacePath: "/tmp/ws",
+      prompt: "hello",
+    });
+
+    assert.deepEqual(calls[0]?.args, [
+      "--print",
+      "--allowed-tools",
+      "Read",
+    ]);
+  });
+
   test("does not set GH_TOKEN/GITHUB_TOKEN when no installation token is provided", async () => {
     const { processRunner, calls } = createRunner();
     const previousGh = process.env.GH_TOKEN;


### PR DESCRIPTION
## Summary
- Add opt-in `modeArgsBuilder` hook to `HeadlessCommandAgentRunner`. The output is appended to base args per spawn so a single runner switches tool permissions by mode.
- Add `buildClaudeToolArgs(mode)`: blocks Edit/Write/MultiEdit/git-mutation in observe; blocks only `git push` in mutate (the runner pushes).
- Wire the claude agent in `src/index.ts` to use `buildClaudeToolArgs`.

## Test plan
- [x] `npm test` (144 tests pass)

Resolves #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)