### PR TITLE
feat(execution): warn when observe leaves workspace modifications

### DIFF
--- a/src/services/execution-service.ts
+++ b/src/services/execution-service.ts
@@ -226,6 +226,16 @@ export class ExecutionService {
         body,
       });
 
+      const dirty =
+        await this.dependencies.workspaceManager.hasChanges(workspace);
+
+      if (dirty) {
+        await this.dependencies.logStore.write(
+          input.task.taskId,
+          "WARN: observe agent left workspace modifications; observe-mode policy violated",
+        );
+      }
+
       await this.dependencies.logStore.write(input.task.taskId, "observe completed");
       return { status: "succeeded" };
     } finally {

--- a/tests/unit/execution-service.test.ts
+++ b/tests/unit/execution-service.test.ts
@@ -399,6 +399,92 @@ describe("ExecutionService", () => {
     assert.match(postedComments[0] ?? "", /issue-comment-reply r1/);
   });
 
+  test("observe logs a WARN if the workspace is dirty after the agent finishes", async () => {
+    const logs: Array<{ taskId: string; message: string }> = [];
+
+    const service = new ExecutionService({
+      githubClient: {
+        getSourceContext: async () => issueContext,
+        getDefaultBranch: async () => "main",
+        getPullRequestState: async () => ({
+          number: 0,
+          isFork: false,
+          state: "open" as const,
+          merged: false,
+          headRef: "feature/x",
+        }),
+        getIssueLabels: async () => ({ labels: [] }),
+        getAppBotInfo: async () => ({
+          id: 1,
+          login: "bot[bot]",
+          slug: "bot",
+        }),
+        getInstallationAccessToken: async () => "test-token",
+        postIssueComment: async () => {},
+        postPullRequestComment: async () => {},
+        findOpenPullRequestByBranch: async () => null,
+        createPullRequest: async () => ({
+          number: 1,
+          url: "https://example.test/pr/1",
+          branchName: "ai/issue-100",
+        }),
+        updatePullRequest: async () => ({
+          number: 1,
+          url: "https://example.test/pr/1",
+          branchName: "ai/issue-100",
+        }),
+      },
+      workspaceManager: {
+        prepareObserveWorkspace: async () => ({ workspacePath: "/tmp/observe" }),
+        prepareMutateWorkspace: async () => ({
+          workspacePath: "/tmp/mutate",
+          branchName: "ai/issue-100",
+        }),
+        preparePrImplementWorkspace: async () => ({
+          workspacePath: "/tmp/pr-implement",
+          branchName: "feature/x",
+        }),
+        hasChanges: async () => true,
+        commitAll: async () => {},
+        pushBranch: async () => {},
+        cleanupWorkspace: async () => {},
+      },
+      agentRegistry: {
+        resolve: () => ({
+          run: async () => ({
+            exitCode: 0,
+            stdout: "Observed",
+            stderr: "",
+          }),
+        }),
+      },
+      logStore: {
+        write: async (taskId, message) => {
+          logs.push({ taskId, message });
+        },
+        cleanupExpired: async () => {},
+      },
+      queueStore: {
+        listTasks: async () => [],
+      },
+    });
+
+    const result = await service.execute({
+      task: createTask("issue-comment-reply"),
+      instruction: observeInstruction,
+    });
+
+    assert.equal(result.status, "succeeded");
+    assert.ok(
+      logs.some((entry) =>
+        entry.message.includes(
+          "observe agent left workspace modifications",
+        ),
+      ),
+      `expected WARN log, got: ${logs.map((l) => l.message).join(" | ")}`,
+    );
+  });
+
   test("skips observe write-back when a newer task supersedes it", async () => {
     const postedComments: string[] = [];
 


### PR DESCRIPTION
## Summary
- Add a `hasChanges` check at the end of `executeObserve`. If the agent mutated the workspace despite the observe tool policy, write a WARN entry to the per-task log so the violation shows up in `journalctl`.
- The task is still marked `succeeded`; this is observability, not enforcement.

## Test plan
- [x] `npm test` (145 tests pass)

Resolves #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)