### PR TITLE
refactor(dispatcher): replace literal branches with RoutingRule[]

### DIFF
--- a/src/domain/rules/event-routing.ts
+++ b/src/domain/rules/event-routing.ts
@@ -1,0 +1,53 @@
+import type { CommandVerb } from "./command-parser.js";
+
+export type EventKind = "issue_opened" | "issue_comment" | "pr_comment";
+
+export interface RoutingInput {
+  eventKind: EventKind;
+  verb: CommandVerb;
+}
+
+export interface RoutingRule {
+  match: (input: RoutingInput) => boolean;
+  instructionId: string;
+}
+
+export const DEFAULT_ROUTING_RULES: RoutingRule[] = [
+  {
+    match: (input) => input.eventKind === "issue_opened",
+    instructionId: "issue-initial-review",
+  },
+  {
+    match: (input) =>
+      input.eventKind === "issue_comment" && input.verb === "implement",
+    instructionId: "issue-implement",
+  },
+  {
+    match: (input) =>
+      input.eventKind === "issue_comment" && input.verb === null,
+    instructionId: "issue-comment-reply",
+  },
+  {
+    match: (input) =>
+      input.eventKind === "pr_comment" && input.verb === "implement",
+    instructionId: "pr-implement",
+  },
+  {
+    match: (input) =>
+      input.eventKind === "pr_comment" && input.verb === null,
+    instructionId: "pr-review-comment",
+  },
+];
+
+export function resolveInstructionId(
+  rules: readonly RoutingRule[],
+  input: RoutingInput,
+): string | null {
+  for (const rule of rules) {
+    if (rule.match(input)) {
+      return rule.instructionId;
+    }
+  }
+
+  return null;
+}

--- a/src/services/event-dispatcher.ts
+++ b/src/services/event-dispatcher.ts
@@ -1,6 +1,11 @@
 import type { RepoRef, SourceRef } from "../domain/task.js";
-import type { AgentRegistry } from "./agent-registry.js";
 import { parseCommand } from "../domain/rules/command-parser.js";
+import {
+  DEFAULT_ROUTING_RULES,
+  resolveInstructionId,
+  type RoutingRule,
+} from "../domain/rules/event-routing.js";
+import type { AgentRegistry } from "./agent-registry.js";
 
 export interface PullRequestState {
   number: number;
@@ -55,15 +60,18 @@ export interface EventDispatcherDependencies {
   agentRegistry: Pick<AgentRegistry, "has" | "getDefaultAgent">;
   botUserId: number;
   noAiLabel?: string;
+  routingRules?: readonly RoutingRule[];
 }
 
 const DEFAULT_NO_AI_LABEL = "no-ai";
 
 export class EventDispatcher {
   private readonly noAiLabel: string;
+  private readonly routingRules: readonly RoutingRule[];
 
   constructor(private readonly deps: EventDispatcherDependencies) {
     this.noAiLabel = deps.noAiLabel ?? DEFAULT_NO_AI_LABEL;
+    this.routingRules = deps.routingRules ?? DEFAULT_ROUTING_RULES;
   }
 
   dispatch(event: DispatchedEvent): DispatchAction {
@@ -92,9 +100,18 @@ export class EventDispatcher {
       };
     }
 
+    const instructionId = resolveInstructionId(this.routingRules, {
+      eventKind: "issue_opened",
+      verb: null,
+    });
+
+    if (instructionId === null) {
+      return { kind: "ignore", reason: "no routing rule matched" };
+    }
+
     return {
       kind: "enqueue",
-      instructionId: "issue-initial-review",
+      instructionId,
       agent: this.deps.agentRegistry.getDefaultAgent(),
       repo: event.repo,
       source: { kind: "issue", number: event.issue.number },
@@ -118,8 +135,14 @@ export class EventDispatcher {
       };
     }
 
-    const instructionId =
-      parsed.verb === "implement" ? "issue-implement" : "issue-comment-reply";
+    const instructionId = resolveInstructionId(this.routingRules, {
+      eventKind: "issue_comment",
+      verb: parsed.verb,
+    });
+
+    if (instructionId === null) {
+      return { kind: "ignore", reason: "no routing rule matched" };
+    }
 
     return {
       kind: "enqueue",
@@ -156,23 +179,20 @@ export class EventDispatcher {
       if (rejection !== null) {
         return rejection;
       }
+    }
 
-      return {
-        kind: "enqueue",
-        instructionId: "pr-implement",
-        agent: parsed.agent,
-        repo: event.repo,
-        source: { kind: "pull_request", number: event.pr.number },
-        requestedBy: event.sender.login,
-        ...(parsed.additionalInstructions.length > 0
-          ? { additionalInstructions: parsed.additionalInstructions }
-          : {}),
-      };
+    const instructionId = resolveInstructionId(this.routingRules, {
+      eventKind: "pr_comment",
+      verb: parsed.verb,
+    });
+
+    if (instructionId === null) {
+      return { kind: "ignore", reason: "no routing rule matched" };
     }
 
     return {
       kind: "enqueue",
-      instructionId: "pr-review-comment",
+      instructionId,
       agent: parsed.agent,
       repo: event.repo,
       source: { kind: "pull_request", number: event.pr.number },

--- a/tests/unit/event-routing.test.ts
+++ b/tests/unit/event-routing.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  DEFAULT_ROUTING_RULES,
+  resolveInstructionId,
+} from "../../src/domain/rules/event-routing.js";
+
+describe("DEFAULT_ROUTING_RULES", () => {
+  test("issue_opened resolves to issue-initial-review", () => {
+    assert.equal(
+      resolveInstructionId(DEFAULT_ROUTING_RULES, {
+        eventKind: "issue_opened",
+        verb: null,
+      }),
+      "issue-initial-review",
+    );
+  });
+
+  test("issue_comment + implement resolves to issue-implement", () => {
+    assert.equal(
+      resolveInstructionId(DEFAULT_ROUTING_RULES, {
+        eventKind: "issue_comment",
+        verb: "implement",
+      }),
+      "issue-implement",
+    );
+  });
+
+  test("issue_comment + null verb resolves to issue-comment-reply", () => {
+    assert.equal(
+      resolveInstructionId(DEFAULT_ROUTING_RULES, {
+        eventKind: "issue_comment",
+        verb: null,
+      }),
+      "issue-comment-reply",
+    );
+  });
+
+  test("pr_comment + implement resolves to pr-implement", () => {
+    assert.equal(
+      resolveInstructionId(DEFAULT_ROUTING_RULES, {
+        eventKind: "pr_comment",
+        verb: "implement",
+      }),
+      "pr-implement",
+    );
+  });
+
+  test("pr_comment + null verb resolves to pr-review-comment", () => {
+    assert.equal(
+      resolveInstructionId(DEFAULT_ROUTING_RULES, {
+        eventKind: "pr_comment",
+        verb: null,
+      }),
+      "pr-review-comment",
+    );
+  });
+
+  test("returns null for an empty rule set", () => {
+    assert.equal(
+      resolveInstructionId([], {
+        eventKind: "issue_opened",
+        verb: null,
+      }),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Move the five `(eventKind, verb) → instructionId` mappings into `src/domain/rules/event-routing.ts` as `DEFAULT_ROUTING_RULES: RoutingRule[]`. New rules are now a single-line addition.
- `EventDispatcher` resolves the instruction id via `resolveInstructionId(rules, { eventKind, verb })`. Preflight rejection logic (fork / merged / closed / deleted head) stays in the service layer (GitHub-shape aware, not pure routing).
- `EventDispatcherDependencies.routingRules` lets the table be overridden per environment or per test.

## Test plan
- [x] `npm run build` (tsc clean)
- [x] `npm test` (151 tests pass; new event-routing test covers the 5 rules + miss case)

Resolves #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)