### PR TITLE
feat(instructions): workflow field + handler dispatch

### DIFF
--- a/definitions/instructions/issue-comment-reply.yaml
+++ b/definitions/instructions/issue-comment-reply.yaml
@@ -1,7 +1,8 @@
 id: issue-comment-reply
-revision: 1
+revision: 2
 source_kind: issue
 mode: observe
+workflow: observe
 context:
   include_issue_body: true
   include_issue_comments: true

--- a/definitions/instructions/issue-implement.yaml
+++ b/definitions/instructions/issue-implement.yaml
@@ -1,7 +1,8 @@
 id: issue-implement
-revision: 1
+revision: 2
 source_kind: issue
 mode: mutate
+workflow: mutate
 context:
   include_issue_body: true
   include_issue_comments: true

--- a/definitions/instructions/issue-initial-review.yaml
+++ b/definitions/instructions/issue-initial-review.yaml
@@ -1,7 +1,8 @@
 id: issue-initial-review
-revision: 1
+revision: 2
 source_kind: issue
 mode: observe
+workflow: observe
 context:
   include_issue_body: true
   include_issue_comments: false

--- a/definitions/instructions/pr-implement.yaml
+++ b/definitions/instructions/pr-implement.yaml
@@ -1,7 +1,8 @@
 id: pr-implement
-revision: 1
+revision: 2
 source_kind: pull_request
 mode: mutate
+workflow: pr_implement
 context:
   include_pr_body: true
   include_pr_comments: true

--- a/definitions/instructions/pr-review-comment.yaml
+++ b/definitions/instructions/pr-review-comment.yaml
@@ -1,7 +1,8 @@
 id: pr-review-comment
-revision: 1
+revision: 2
 source_kind: pull_request
 mode: observe
+workflow: observe
 context:
   include_pr_body: true
   include_pr_comments: true

--- a/src/domain/instruction.ts
+++ b/src/domain/instruction.ts
@@ -2,6 +2,8 @@ import type { SourceKind } from "./task.js";
 
 export type ExecutionMode = "observe" | "mutate";
 
+export type InstructionWorkflow = "observe" | "mutate" | "pr_implement";
+
 export interface InstructionContext {
   includeIssueBody?: boolean;
   includeIssueComments?: boolean;
@@ -29,6 +31,7 @@ export interface InstructionDefinition {
   revision: number;
   sourceKind: SourceKind;
   mode: ExecutionMode;
+  workflow: InstructionWorkflow;
   context: InstructionContext;
   githubActions: string[];
   permissions: InstructionPermissions;

--- a/src/infra/instructions/instruction-loader.ts
+++ b/src/infra/instructions/instruction-loader.ts
@@ -13,6 +13,7 @@ interface RawInstructionDefinition {
   revision: number;
   source_kind: InstructionDefinition["sourceKind"];
   mode: InstructionDefinition["mode"];
+  workflow: InstructionDefinition["workflow"];
   context?: Record<string, boolean>;
   permissions: {
     code_read: boolean;
@@ -82,6 +83,7 @@ export async function loadInstructionDefinition({
     revision: raw.revision,
     sourceKind: raw.source_kind,
     mode: raw.mode,
+    workflow: raw.workflow,
     context: mapContext(raw.context),
     permissions: mapPermissions(raw.permissions),
     githubActions: raw.github_actions,

--- a/src/services/execution-service.ts
+++ b/src/services/execution-service.ts
@@ -56,22 +56,20 @@ export class ExecutionService {
       input.instruction.context,
     );
 
-    if (input.instruction.id === "pr-implement") {
-      if (context.kind !== "pull_request") {
-        return this.fail(
-          input.task.taskId,
-          "pr-implement requires a pull_request source",
-        );
-      }
-
-      return this.executePrImplement(input, context);
+    switch (input.instruction.workflow) {
+      case "observe":
+        return this.executeObserve(input, context);
+      case "mutate":
+        return this.executeMutate(input, context);
+      case "pr_implement":
+        if (context.kind !== "pull_request") {
+          return this.fail(
+            input.task.taskId,
+            "pr_implement workflow requires a pull_request source",
+          );
+        }
+        return this.executePrImplement(input, context);
     }
-
-    if (input.instruction.mode === "observe") {
-      return this.executeObserve(input, context);
-    }
-
-    return this.executeMutate(input, context);
   }
 
   private async executePrImplement(

--- a/tests/unit/enqueue-service.test.ts
+++ b/tests/unit/enqueue-service.test.ts
@@ -8,6 +8,7 @@ const issueImplementInstruction: InstructionDefinition = {
   revision: 1,
   sourceKind: "issue",
   mode: "mutate",
+  workflow: "mutate",
   context: {
     includeIssueBody: true,
     includeIssueComments: true,

--- a/tests/unit/execution-prompt-builder.test.ts
+++ b/tests/unit/execution-prompt-builder.test.ts
@@ -30,6 +30,7 @@ const observeInstruction: InstructionDefinition = {
   revision: 1,
   sourceKind: "issue",
   mode: "observe",
+  workflow: "observe",
   context: {},
   permissions: {
     codeRead: true,
@@ -49,6 +50,7 @@ const mutateInstruction: InstructionDefinition = {
   ...observeInstruction,
   id: "issue-implement",
   mode: "mutate",
+  workflow: "mutate",
   permissions: {
     codeRead: true,
     codeWrite: true,

--- a/tests/unit/execution-service.test.ts
+++ b/tests/unit/execution-service.test.ts
@@ -11,6 +11,7 @@ const observeInstruction: InstructionDefinition = {
   revision: 1,
   sourceKind: "issue",
   mode: "observe",
+  workflow: "observe",
   context: {
     includeIssueBody: true,
     includeIssueComments: true,
@@ -34,6 +35,7 @@ const mutateInstruction: InstructionDefinition = {
   revision: 1,
   sourceKind: "issue",
   mode: "mutate",
+  workflow: "mutate",
   context: {
     includeIssueBody: true,
     includeIssueComments: true,
@@ -58,6 +60,7 @@ const prImplementInstruction: InstructionDefinition = {
   revision: 1,
   sourceKind: "pull_request",
   mode: "mutate",
+  workflow: "pr_implement",
   context: {
     includePrBody: true,
     includePrComments: true,
@@ -82,6 +85,7 @@ const pullRequestObserveInstruction: InstructionDefinition = {
   revision: 1,
   sourceKind: "pull_request",
   mode: "observe",
+  workflow: "observe",
   context: {
     includePrBody: true,
     includePrComments: true,

--- a/tests/unit/headless-command-agent-runner.test.ts
+++ b/tests/unit/headless-command-agent-runner.test.ts
@@ -15,6 +15,7 @@ const instruction: InstructionDefinition = {
   revision: 1,
   sourceKind: "issue",
   mode: "observe",
+  workflow: "observe",
   context: {},
   permissions: {
     codeRead: true,

--- a/tests/unit/instruction-loader.test.ts
+++ b/tests/unit/instruction-loader.test.ts
@@ -85,4 +85,23 @@ describe("loadInstructionDefinition", () => {
       false,
     );
   });
+
+  test("workflow field maps observe/mutate/pr_implement from yaml", async () => {
+    const observe = await loadInstructionDefinition({
+      definitionsDir,
+      instructionId: "issue-initial-review",
+    });
+    const mutate = await loadInstructionDefinition({
+      definitionsDir,
+      instructionId: "issue-implement",
+    });
+    const prImplement = await loadInstructionDefinition({
+      definitionsDir,
+      instructionId: "pr-implement",
+    });
+
+    assert.equal(observe.workflow, "observe");
+    assert.equal(mutate.workflow, "mutate");
+    assert.equal(prImplement.workflow, "pr_implement");
+  });
 });

--- a/tests/unit/runner-daemon.test.ts
+++ b/tests/unit/runner-daemon.test.ts
@@ -10,6 +10,7 @@ const instruction: InstructionDefinition = {
   revision: 1,
   sourceKind: "issue",
   mode: "observe",
+  workflow: "observe",
   context: {},
   permissions: {
     codeRead: true,

--- a/tests/unit/scheduler-service.test.ts
+++ b/tests/unit/scheduler-service.test.ts
@@ -9,6 +9,7 @@ const observeInstruction: InstructionDefinition = {
   revision: 1,
   sourceKind: "issue",
   mode: "observe",
+  workflow: "observe",
   context: {},
   permissions: {
     codeRead: true,
@@ -29,6 +30,7 @@ const mutateInstruction: InstructionDefinition = {
   revision: 1,
   sourceKind: "issue",
   mode: "mutate",
+  workflow: "mutate",
   context: {},
   permissions: {
     codeRead: true,


### PR DESCRIPTION
## Summary
- Add `InstructionWorkflow = "observe" | "mutate" | "pr_implement"` and a required `workflow` field on `InstructionDefinition`. YAML loader maps the new key.
- `ExecutionService.execute` now switches on `input.instruction.workflow` instead of the literal id `pr-implement` plus `instruction.mode`.
- `mode` and `workflow` are deliberately distinct: `mode` drives prompt policy + tool policy; `workflow` drives executor branch.
- All five instruction yamls bump revision 1 → 2 and gain `workflow`.

## Test plan
- [x] `npm run build` (tsc clean)
- [x] `npm test` (152 tests pass; new loader assertion covers workflow parsing)

## Deploy note
Recommended to deploy when the queue is empty so revision 1 → 2 doesn't race with in-flight tasks.

Resolves #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)