### PR TITLE
ops: split dev and deploy clones

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,4 +38,4 @@ jobs:
               -o BatchMode=yes \
               -o ConnectTimeout=10 \
               ubuntu@github-runner \
-              'bash /home/ubuntu/oh-my-github-runner/ops/scripts/deploy.sh'
+              'bash /home/ubuntu/runner-deploy/ops/scripts/deploy.sh'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -151,7 +151,7 @@ tags are introduced for this repo.
 ```sh
 # After pushing to main, watch the workflow run, then on the VM:
 journalctl -u oh-my-github-runner.service -n 50 -f
-git -C ~/oh-my-github-runner log -1 --format='%h %s'
+git -C /home/ubuntu/runner-deploy log -1 --format='%h %s'
 ```
 
 If the deploy script no-ops because the VM is already at the requested
@@ -159,12 +159,43 @@ commit (e.g., a manual `git pull` ran first), the workflow logs
 `Already at <sha>; nothing to deploy.` and exits 0. The service is
 left untouched.
 
+## Working on the runner from the VM
+
+```
+/home/ubuntu/runner-deploy/        # what systemd runs — do NOT edit by hand
+/home/ubuntu/oh-my-github-runner/  # dev clone (optional) — edit here
+```
+
+The deploy script `git reset --hard origin/main` on `runner-deploy`
+unconditionally on every run, so any uncommitted edit there is lost.
+Edit code in the dev clone (or off the VM entirely), commit, push,
+let the workflow propagate it. The dev clone exists only because Claude
+Code runs on this VM; if you operate from a laptop you can skip it.
+
 ## Operational tips
 
 - Logs: `journalctl -u oh-my-github-runner.service -f`
 - Tunnel logs: `journalctl -u cloudflared.service -f`
-- Manual rate-limit reset: `rm ~/oh-my-github-runner/var/queue/state.json`
+- Current commit on the VM: `git -C /home/ubuntu/runner-deploy log -1 --oneline`
+- Manual rate-limit reset: `rm /home/ubuntu/runner-deploy/var/queue/state.json`
 - Recovery from crash: `recoverRunningTasks` runs at startup and marks
-  in-flight tasks as failed; orphaned workspaces are not cleaned automatically
-  in v1
-- Manual deploy: `ssh ubuntu@github-runner 'bash ~/oh-my-github-runner/ops/scripts/deploy.sh'`
+  in-flight tasks as failed. The daemon's `notifyTaskFailure` callback
+  posts a `Task <id> failed before completion: <summary>` comment to the
+  originating issue or PR. Orphaned workspaces under `var/workspaces/`
+  are not cleaned automatically in v1.
+- Manual deploy: `ssh ubuntu@github-runner 'bash /home/ubuntu/runner-deploy/ops/scripts/deploy.sh'`
+- When deploying a change that bumps an instruction `revision` in
+  `definitions/instructions/*.yaml`, prefer to deploy when the queue is
+  empty (`jq '[.[] | select(.status=="running" or .status=="queued")] | length' var/queue/tasks.json`).
+  In-flight tasks pinned to the old revision will keep running with the
+  old prompt; new tasks pick up the new revision.
+
+## Recommended GitHub setup (not enforced by code)
+
+- **Branch protection on `main`**: require pull request, disallow direct
+  push, disallow force push. The runner never pushes directly to `main`
+  (`buildBranchName` always produces `ai/<kind>-<number>`), but server-
+  side branch protection is the backstop if a future change to the
+  runner ever forgets that invariant.
+- **Required status checks on PRs**: none in v1; build/test runs
+  locally on the VM only at deploy time.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -27,21 +27,30 @@ that user's home directory; secrets live under `/etc`.
 ## Layout
 
 ```
-/home/ubuntu/oh-my-github-runner/        # cloned source + dist/ + var/
+/home/ubuntu/runner-deploy/              # deploy clone — what systemd runs;
+                                         # owns dist/ and var/ (queue, logs,
+                                         # repo mirrors, workspaces)
+/home/ubuntu/oh-my-github-runner/        # (optional) dev clone — where you
+                                         # edit code; not touched by deploy
 /etc/oh-my-github-runner/runner.env      # env file (see .env.example)
 /etc/oh-my-github-runner/github-app.pem  # GitHub App private key
 /etc/cloudflared/config.yml              # tunnel ingress
 ```
+
+The dev clone is optional — only the `runner-deploy` clone has to exist on
+the VM. Splitting them keeps editor / linter / build artifacts isolated
+from the running daemon and prevents `git reset --hard` (run by the deploy
+script) from clobbering an in-progress edit.
 
 ## Install
 
 ```sh
 sudo mkdir -p /etc/oh-my-github-runner
 
-# fetch + first build
+# fetch + first build (deploy clone)
 git clone https://github.com/SanGyuk-Raccoon/oh-my-github-runner.git \
-  ~/oh-my-github-runner
-cd ~/oh-my-github-runner
+  /home/ubuntu/runner-deploy
+cd /home/ubuntu/runner-deploy
 npm ci
 npm run compile
 

--- a/ops/scripts/deploy.sh
+++ b/ops/scripts/deploy.sh
@@ -6,7 +6,7 @@
 #   <ssh_user> ALL=(root) NOPASSWD: /bin/systemctl restart oh-my-github-runner.service
 set -euo pipefail
 
-REPO_ROOT=${REPO_ROOT:-/home/ubuntu/oh-my-github-runner}
+REPO_ROOT=${REPO_ROOT:-/home/ubuntu/runner-deploy}
 SERVICE=${SERVICE:-oh-my-github-runner.service}
 
 cd "$REPO_ROOT"

--- a/ops/systemd/oh-my-github-runner.service
+++ b/ops/systemd/oh-my-github-runner.service
@@ -4,9 +4,9 @@ After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=/home/ubuntu/oh-my-github-runner
+WorkingDirectory=/home/ubuntu/runner-deploy
 EnvironmentFile=/etc/oh-my-github-runner/runner.env
-ExecStart=/usr/bin/node /home/ubuntu/oh-my-github-runner/dist/src/index.js
+ExecStart=/usr/bin/node /home/ubuntu/runner-deploy/dist/src/index.js
 Restart=always
 RestartSec=5
 User=ubuntu


### PR DESCRIPTION
## Summary
- Move the runtime / deploy root to `/home/ubuntu/runner-deploy` so the dev clone (where code is edited) no longer overlaps with the working tree the deploy script `git reset --hard`'s.
- Updates `deploy.sh` `REPO_ROOT` default, the systemd unit's `WorkingDirectory` + `ExecStart`, the workflow's SSH command, and `docs/deployment.md` layout.

## Migration on the VM (manual, one-time)
```sh
sudo systemctl stop oh-my-github-runner.service
mv /home/ubuntu/oh-my-github-runner/var /home/ubuntu/runner-deploy/var
sudo cp /home/ubuntu/runner-deploy/ops/systemd/oh-my-github-runner.service \
        /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl start oh-my-github-runner.service
```
The new clone is already prepared at `/home/ubuntu/runner-deploy` with `npm ci && npm run compile` done.

## Test plan
- [x] `npm run build` (tsc clean)
- [ ] post-merge: verify daemon comes up from `/home/ubuntu/runner-deploy/dist/src/index.js`, queue state preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)