### PR TITLE
feat(dispatcher): ALLOWED_SENDER_IDS gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-RUNNER_ROOT=/home/ubuntu/oh-my-github-runner
+RUNNER_ROOT=/home/ubuntu/runner-deploy
 RUNNER_POLL_INTERVAL_MS=2000
 RUNNER_MAX_CONCURRENCY=2
 RUNNER_LOG_RETENTION_DAYS=3
@@ -9,6 +9,11 @@ GITHUB_APP_PRIVATE_KEY_PATH=/etc/oh-my-github-runner/github-app.pem
 GITHUB_WEBHOOK_SECRET=replace-with-the-secret-set-in-the-github-app
 GITHUB_API_BASE_URL=https://api.github.com
 GITHUB_WEB_BASE_URL=https://github.com
+
+# Sender allowlist — comma-separated GitHub user IDs allowed to trigger tasks.
+# Find your id with: gh api /users/<login> --jq .id
+# Required: webhook events from any other sender are dropped.
+ALLOWED_SENDER_IDS=12345678
 
 # Webhook server (bind to localhost; Cloudflare tunnel terminates TLS upstream)
 WEBHOOK_PORT=8080

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -83,6 +83,9 @@ the following are missing:
 - `GITHUB_WEBHOOK_SECRET`
 - `AGENTS` (comma-separated list, e.g. `claude`)
 - `<AGENT>_COMMAND` for each entry in `AGENTS`
+- `ALLOWED_SENDER_IDS` (comma-separated GitHub user IDs allowed to trigger
+  tasks via webhook; events from any other sender are dropped before
+  enqueue. Look up an id with `gh api /users/<login> --jq .id`.)
 
 ## State files
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,30 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function parseSenderIdAllowlist(name: string): Set<number> {
+  const raw = requireEnv(name);
+  const ids = new Set<number>();
+
+  for (const part of raw.split(",")) {
+    const trimmed = part.trim();
+    if (trimmed.length === 0) continue;
+
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error(
+        `${name} contains a non-integer or non-positive entry: '${trimmed}'`,
+      );
+    }
+    ids.add(parsed);
+  }
+
+  if (ids.size === 0) {
+    throw new Error(`${name} must list at least one sender id`);
+  }
+
+  return ids;
+}
+
 export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
   const runnerRoot = process.env.RUNNER_ROOT ?? process.cwd();
   const pollIntervalMs = parsePositiveInt(
@@ -187,9 +211,12 @@ export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
     throw new Error(`Invalid bot user id: ${botUserId}`);
   }
 
+  const allowedSenderIds = parseSenderIdAllowlist("ALLOWED_SENDER_IDS");
+
   const dispatcher = new EventDispatcher({
     agentRegistry,
     botUserId,
+    allowedSenderIds,
   });
 
   const webhookHandler = new WebhookHandler({

--- a/src/services/event-dispatcher.ts
+++ b/src/services/event-dispatcher.ts
@@ -59,6 +59,7 @@ export type DispatchAction =
 export interface EventDispatcherDependencies {
   agentRegistry: Pick<AgentRegistry, "has" | "getDefaultAgent">;
   botUserId: number;
+  allowedSenderIds: ReadonlySet<number>;
   noAiLabel?: string;
   routingRules?: readonly RoutingRule[];
 }
@@ -77,6 +78,13 @@ export class EventDispatcher {
   dispatch(event: DispatchedEvent): DispatchAction {
     if (event.sender.id === this.deps.botUserId) {
       return { kind: "ignore", reason: "sender is our app's bot" };
+    }
+
+    if (!this.deps.allowedSenderIds.has(event.sender.id)) {
+      return {
+        kind: "ignore",
+        reason: `sender id ${event.sender.id} (login=${event.sender.login}) not in allowlist`,
+      };
     }
 
     if (event.kind === "issue_opened") {

--- a/tests/integration/issue-opened-flow.test.ts
+++ b/tests/integration/issue-opened-flow.test.ts
@@ -36,6 +36,7 @@ describe("integration: issue-opened webhook produces an enqueued task", () => {
           getDefaultAgent: () => "claude",
         },
         botUserId: 9999,
+        allowedSenderIds: new Set([42, 100, 200]),
       });
 
       const handler = new WebhookHandler({

--- a/tests/unit/event-dispatcher.test.ts
+++ b/tests/unit/event-dispatcher.test.ts
@@ -8,13 +8,17 @@ import type {
 
 const repo = { owner: "octo", name: "repo" } as const;
 
-function makeDispatcher(options?: { botUserId?: number }): EventDispatcher {
+function makeDispatcher(options?: {
+  botUserId?: number;
+  allowedSenderIds?: ReadonlySet<number>;
+}): EventDispatcher {
   return new EventDispatcher({
     agentRegistry: {
       has: (name: string) => name === "claude",
       getDefaultAgent: () => "claude",
     },
     botUserId: options?.botUserId ?? 9999,
+    allowedSenderIds: options?.allowedSenderIds ?? new Set([100, 101, 102]),
   });
 }
 
@@ -249,6 +253,74 @@ describe("EventDispatcher", () => {
     assert.equal(action.kind, "ignore");
     if (action.kind !== "ignore") return;
     assert.match(action.reason, /not registered/);
+  });
+
+  test("ignores issue.opened from a sender outside the allowlist", () => {
+    const dispatcher = makeDispatcher();
+
+    const action = dispatcher.dispatch({
+      kind: "issue_opened",
+      repo,
+      issue: { number: 1, labels: [] },
+      sender: { id: 999, login: "stranger" },
+    });
+
+    assert.equal(action.kind, "ignore");
+    if (action.kind !== "ignore") return;
+    assert.match(action.reason, /not in allowlist/);
+    assert.match(action.reason, /999/);
+    assert.match(action.reason, /stranger/);
+  });
+
+  test("ignores issue_comment from a sender outside the allowlist even with a valid command", () => {
+    const dispatcher = makeDispatcher();
+
+    const action = dispatcher.dispatch({
+      kind: "issue_comment",
+      repo,
+      issue: { number: 1 },
+      comment: { body: "/claude implement" },
+      sender: { id: 999, login: "stranger" },
+    });
+
+    assert.equal(action.kind, "ignore");
+    if (action.kind !== "ignore") return;
+    assert.match(action.reason, /not in allowlist/);
+  });
+
+  test("ignores pr_comment from a sender outside the allowlist", () => {
+    const dispatcher = makeDispatcher();
+
+    const action = dispatcher.dispatch({
+      kind: "pr_comment",
+      repo,
+      pr: pr({ number: 5 }),
+      comment: { body: "/claude implement" },
+      sender: { id: 999, login: "stranger" },
+    });
+
+    assert.equal(action.kind, "ignore");
+    if (action.kind !== "ignore") return;
+    assert.match(action.reason, /not in allowlist/);
+  });
+
+  test("bot self-loop check fires before the allowlist check", () => {
+    const dispatcher = makeDispatcher({
+      botUserId: 1,
+      allowedSenderIds: new Set([100]),
+    });
+
+    const action = dispatcher.dispatch({
+      kind: "issue_comment",
+      repo,
+      issue: { number: 1 },
+      comment: { body: "/claude" },
+      sender: { id: 1, login: "our-bot" },
+    });
+
+    assert.equal(action.kind, "ignore");
+    if (action.kind !== "ignore") return;
+    assert.match(action.reason, /our app's bot/);
   });
 
   // Stable export reference (ensures the type alias survives)

--- a/tests/unit/webhook-handler.test.ts
+++ b/tests/unit/webhook-handler.test.ts
@@ -44,6 +44,7 @@ function buildHarness(options: HarnessOptions = {}): Harness {
       getDefaultAgent: () => "claude",
     },
     botUserId,
+    allowedSenderIds: new Set([1, 100, 200]),
   });
 
   const handler = new WebhookHandler({


### PR DESCRIPTION
## Summary
- New required env var `ALLOWED_SENDER_IDS` (comma-separated GitHub user IDs). Webhook events from any other sender are dropped at dispatch time before routing — bot self-loop check still runs first.
- Daemon refuses to start if the var is unset, empty, or contains non-integer / non-positive entries.
- Prerequisite for making the repo public: without it, any stranger opening an issue triggers a paid Claude run.

## Deploy step (after merge)
Add `ALLOWED_SENDER_IDS=56672129` to `/etc/oh-my-github-runner/runner.env` (the id for `SanGyuk-Raccoon`), then `sudo systemctl restart oh-my-github-runner.service`. Without this the daemon will fail to start after the next deploy.

## Test plan
- [x] `npm run build` (tsc clean)
- [x] `npm test` (156 tests pass; new tests cover non-allowlist sender for all 3 dispatch kinds + bot-check-precedes-allowlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)