### PR TITLE
feat(agent): block gh pr merge so only user can merge to main

### DIFF
--- a/src/domain/rules/execution-prompt.ts
+++ b/src/domain/rules/execution-prompt.ts
@@ -69,6 +69,7 @@ export class ExecutionPromptBuilder {
       "- You may read and write files in the workspace, run `git add`, `git commit`, and `git push`.",
       "- The current branch is set up for you (typically `ai/<source-kind>-<number>`); push that branch directly with `git push -u origin HEAD`. Direct pushes to `main` are server-protected — every change to `main` must go through a pull request.",
       "- After pushing, open the PR yourself with `gh pr create` (or update an existing one with `gh pr edit` / a new commit). Pick a clear title and write the PR body — it is your output to the user.",
+      "- You MUST NOT merge the PR. `gh pr merge` is blocked for you. Merging into `main` is the user's call after they review your PR.",
       "- You may also use `gh` for any side effects you judge useful: filing follow-up issues for out-of-scope work, commenting on the source issue/PR, adding labels, etc. The runner does not post anything for you besides a daemon-level failure notice if the task crashes.",
       "- If you conclude no file change is appropriate, exit cleanly. Communicate the reasoning to the user via `gh issue comment` / `gh pr comment` on the source so they see it on GitHub.",
     ];

--- a/src/infra/agent/agent-tool-policies.ts
+++ b/src/infra/agent/agent-tool-policies.ts
@@ -13,5 +13,7 @@ export function buildClaudeToolArgs(mode: ExecutionMode): string[] {
   return [
     "--allowed-tools",
     "Read Grep Glob Edit Write MultiEdit Bash(gh:*) Bash(git:*) Bash(npm:*) Bash(node:*)",
+    "--disallowed-tools",
+    "Bash(gh pr merge:*)",
   ];
 }

--- a/tests/unit/agent-tool-policies.test.ts
+++ b/tests/unit/agent-tool-policies.test.ts
@@ -27,21 +27,24 @@ describe("buildClaudeToolArgs", () => {
     assert.match(disallowed, /Bash\(git add:\*\)/);
   });
 
-  test("mutate mode allows edits, gh, and full git (push enforcement is server-side)", () => {
+  test("mutate mode allows edits/git/gh but blocks gh pr merge", () => {
     const args = buildClaudeToolArgs("mutate");
 
     const allowedIdx = args.indexOf("--allowed-tools");
+    const disallowedIdx = args.indexOf("--disallowed-tools");
     assert.ok(allowedIdx >= 0);
+    assert.ok(disallowedIdx >= 0);
 
     const allowed = args[allowedIdx + 1] ?? "";
+    const disallowed = args[disallowedIdx + 1] ?? "";
 
     assert.match(allowed, /\bEdit\b/);
     assert.match(allowed, /\bWrite\b/);
     assert.match(allowed, /Bash\(gh:\*\)/);
     assert.match(allowed, /Bash\(git:\*\)/);
 
-    // No --disallowed-tools in mutate: pushes to main are blocked by the
-    // GitHub branch protection ruleset, not by client-side tool filtering.
-    assert.equal(args.indexOf("--disallowed-tools"), -1);
+    // gh pr merge is the user's call. Direct push to main is blocked by
+    // the GitHub ruleset, not by client-side tool filtering.
+    assert.match(disallowed, /Bash\(gh pr merge:\*\)/);
   });
 });

--- a/tests/unit/execution-prompt-builder.test.ts
+++ b/tests/unit/execution-prompt-builder.test.ts
@@ -76,7 +76,7 @@ describe("ExecutionPromptBuilder", () => {
     assert.match(prompt, /runner does not write back/);
   });
 
-  test("mutate prompts allow push and tell the agent to commit, push, and open the PR itself", () => {
+  test("mutate prompts allow push and gh pr create but tell the agent not to merge", () => {
     const prompt = new ExecutionPromptBuilder().build({
       task: baseTask,
       instruction: mutateInstruction,
@@ -88,5 +88,7 @@ describe("ExecutionPromptBuilder", () => {
     assert.match(prompt, /git push/);
     assert.match(prompt, /gh pr create/);
     assert.match(prompt, /server-protected/);
+    assert.match(prompt, /MUST NOT merge/);
+    assert.match(prompt, /gh pr merge.*blocked/);
   });
 });


### PR DESCRIPTION
## Summary

With ruleset `required_approving_review_count` set to 0, the merge gate is now: every change must go through a PR (ruleset), but no approvals are required (so the solo operator isn't blocked on their own work). Add a tool-policy block on `Bash(gh pr merge:*)` so the agent can do everything (push, `gh pr create`, comment, issue) **except** merge — that step is reserved for the human.

- Mutate `--disallowed-tools` = `Bash(gh pr merge:*)` (only this; `git push` and other gh ops remain allowed; main is server-protected by the ruleset).
- Mutate prompt: agent is told explicitly that `gh pr merge` is blocked and that merging is the user's call.

## Test plan
- [x] `npm run build` (tsc clean)
- [x] `npm test` (154 tests pass)
- [ ] Live: `/claude implement` — agent should push branch, `gh pr create`, exit; PR sits unmerged until user clicks merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)