### PR TITLE
feat(prompt): per-instruction persona + sibling guidance md

### DIFF
--- a/definitions/instructions/issue-comment-reply.yaml
+++ b/definitions/instructions/issue-comment-reply.yaml
@@ -3,6 +3,7 @@ revision: 3
 source_kind: issue
 mode: observe
 workflow: observe
+persona: architecture
 context:
   include_issue_body: true
   include_issue_comments: true

--- a/definitions/instructions/issue-implement.md
+++ b/definitions/instructions/issue-implement.md
@@ -1,0 +1,22 @@
+# Issue → Implement Guidance
+
+The PR you create resolves the source issue and is the primary artifact the reviewer (the user) will read. Two jobs: (1) make GitHub auto-close the issue, (2) make the PR body easy to review.
+
+## Auto-close the source issue
+
+- Include `Closes #<source-number>` on its own line in the PR body. The source number is in the `Source:` line of this prompt.
+- If you push more commits later and rewrite the body via `gh pr edit --body`, re-include the `Closes` line — `--body` overwrites the whole body.
+- If — after investigating — you decide *not* to ship a code change, omit the `Closes` line and explain the no-op conclusion via `gh issue comment` instead. Closing the issue is for real implementation, not no-op outcomes.
+
+## PR body shape (reviewer-oriented)
+
+The persona already specifies the base structure (한 줄 요약 → 변경 파일 목록 → 검증 방법 → 후속). On top of that, write the body for someone who will **not** read every line of the diff. Make it possible for the reviewer to decide *where to look first* and *how hard to look*.
+
+Add these explicit sections (omit any that genuinely don't apply — don't pad). Headings stay in Korean because the body itself is Korean:
+
+- **변경의 핵심** — One sentence on *what the PR actually changed and why*. Capture the behavior, contract, or data-flow effect of the change. Do not just paraphrase the issue title.
+- **리뷰 포인트** — One to three concrete `<file>:<line>` spots the reviewer should look at hardest. Pick the places where regressions would hurt (race windows, fallback branches, new external calls, response-mapping seams, permission boundaries) and say *what evidence makes you confident they are safe* (which test, which manual check). Skip this section if the PR is a pure rename or format pass.
+- **의도적으로 안 한 것** — Adjacent work you deliberately did not touch. Include the follow-up issue number if you opened one. Goal: head off the reviewer's "did you forget X?" question.
+- **트레이드오프** — Only the decisions where there was no obvious right answer (e.g. one GraphQL call vs N REST calls, isolated fallback vs hard fail). Skip when the change is unambiguous.
+
+The reviewer should be able to read the body alone and decide *where to look first and how hard*. Do not require the reviewer to follow the diff line by line.

--- a/definitions/instructions/issue-implement.yaml
+++ b/definitions/instructions/issue-implement.yaml
@@ -1,8 +1,9 @@
 id: issue-implement
-revision: 3
+revision: 4
 source_kind: issue
 mode: mutate
 workflow: mutate
+persona: implementation
 context:
   include_issue_body: true
   include_issue_comments: true

--- a/definitions/instructions/issue-initial-review.yaml
+++ b/definitions/instructions/issue-initial-review.yaml
@@ -3,6 +3,7 @@ revision: 3
 source_kind: issue
 mode: observe
 workflow: observe
+persona: architecture
 context:
   include_issue_body: true
   include_issue_comments: false

--- a/definitions/instructions/pr-implement.yaml
+++ b/definitions/instructions/pr-implement.yaml
@@ -1,8 +1,9 @@
 id: pr-implement
-revision: 3
+revision: 4
 source_kind: pull_request
 mode: mutate
 workflow: pr_implement
+persona: implementation
 context:
   include_pr_body: true
   include_pr_comments: true

--- a/definitions/instructions/pr-review-comment.yaml
+++ b/definitions/instructions/pr-review-comment.yaml
@@ -3,6 +3,7 @@ revision: 3
 source_kind: pull_request
 mode: observe
 workflow: observe
+persona: architecture
 context:
   include_pr_body: true
   include_pr_comments: true

--- a/src/domain/instruction.ts
+++ b/src/domain/instruction.ts
@@ -31,6 +31,8 @@ export interface InstructionDefinition {
   sourceKind: SourceKind;
   mode: ExecutionMode;
   workflow: InstructionWorkflow;
+  persona: string;
+  guidance?: string;
   context: InstructionContext;
   githubActions: string[];
   permissions: InstructionPermissions;

--- a/src/domain/rules/execution-prompt.ts
+++ b/src/domain/rules/execution-prompt.ts
@@ -20,124 +20,155 @@ export type ModePolicies = Record<ExecutionMode, string>;
 
 export interface ExecutionPromptBuilderOptions {
   commonRules: string;
-  persona: string;
+  personas: Record<string, string>;
   modePolicies: ModePolicies;
 }
 
 export class ExecutionPromptBuilder {
-  private readonly preamble: string;
+  private readonly commonRules: string;
+  private readonly personas: Record<string, string>;
   private readonly modePolicies: ModePolicies;
 
   constructor(options: ExecutionPromptBuilderOptions) {
-    this.preamble = [options.commonRules, options.persona]
-      .map((part) => part.trim())
-      .filter((part) => part.length > 0)
-      .join("\n\n");
+    this.commonRules = options.commonRules.trim();
+    this.personas = options.personas;
     this.modePolicies = options.modePolicies;
   }
 
   build(input: BuildExecutionPromptInput): string {
-    const { context, instruction, task } = input;
-    const policy = this.modePolicies[instruction.mode].trim();
-    const lines = [
+    const sections: string[] = [];
+
+    const preamble = this.renderPreamble(input.instruction);
+    if (preamble !== null) sections.push(preamble);
+
+    sections.push(this.renderHeader(input));
+    sections.push(this.renderPolicy(input.instruction.mode));
+
+    const guidance = this.renderGuidance(input.instruction);
+    if (guidance !== null) sections.push(guidance);
+
+    sections.push(this.renderData(input.context, input.instruction));
+
+    const userAdditional = this.renderUserAdditional(
+      input.task.additionalInstructions,
+    );
+    if (userAdditional !== null) sections.push(userAdditional);
+
+    return sections.join("\n\n");
+  }
+
+  private renderPreamble(instruction: InstructionDefinition): string | null {
+    const persona = this.personas[instruction.persona];
+    if (persona === undefined) {
+      throw new Error(
+        `Unknown persona '${instruction.persona}' for instruction '${instruction.id}'`,
+      );
+    }
+    const parts = [this.commonRules, persona.trim()].filter(
+      (part) => part.length > 0,
+    );
+    if (parts.length === 0) return null;
+    return parts.join("\n\n");
+  }
+
+  private renderHeader(input: BuildExecutionPromptInput): string {
+    const { task, context, instruction } = input;
+    return [
       `Instruction: ${instruction.id}`,
-      "Policy:",
-      policy,
       `Repository: ${task.repo.owner}/${task.repo.name}`,
       `Source: ${task.source.kind} #${task.source.number}`,
       `Title: ${context.title}`,
-    ];
+    ].join("\n");
+  }
+
+  private renderPolicy(mode: ExecutionMode): string {
+    return ["Policy:", this.modePolicies[mode].trim()].join("\n");
+  }
+
+  private renderGuidance(instruction: InstructionDefinition): string | null {
+    if (instruction.guidance === undefined || instruction.guidance.length === 0) {
+      return null;
+    }
+    return ["Instruction guidance:", instruction.guidance.trim()].join("\n");
+  }
+
+  private renderData(
+    context: GitHubSourceContext,
+    instruction: InstructionDefinition,
+  ): string {
+    const blocks: string[] = [];
 
     if (context.kind === "issue") {
       if (instruction.context.includeIssueBody === true) {
-        this.appendBodySection(lines, context.body);
+        blocks.push(renderBodyBlock(context.body));
       }
-
       if (instruction.context.includeIssueComments === true) {
-        this.appendCommentsSection(lines, context.comments);
+        blocks.push(renderCommentsBlock(context.comments));
       }
-
-      this.appendLinkedRefsSection(lines, context.linkedRefs, "issue");
-      this.appendAdditionalInstructions(lines, task.additionalInstructions);
-      return this.withPreamble(lines.join("\n"));
+      blocks.push(renderLinkedRefsBlock(context.linkedRefs, "issue"));
+      return blocks.join("\n\n");
     }
 
     if (instruction.context.includePrBody === true) {
-      this.appendBodySection(lines, context.body);
+      blocks.push(renderBodyBlock(context.body));
     }
-
     if (instruction.context.includePrComments === true) {
-      this.appendCommentsSection(lines, context.comments);
+      blocks.push(renderCommentsBlock(context.comments));
     }
-
     if (instruction.context.includePrDiff === true) {
-      lines.push("", "Diff:", context.diff);
+      blocks.push(`Diff:\n${context.diff}`);
     }
-
-    lines.push("", `Base: ${context.baseRef}`, `Head: ${context.headRef}`);
-    this.appendLinkedRefsSection(lines, context.linkedRefs, "pull_request");
-    this.appendAdditionalInstructions(lines, task.additionalInstructions);
-    return this.withPreamble(lines.join("\n"));
+    blocks.push(`Base: ${context.baseRef}\nHead: ${context.headRef}`);
+    blocks.push(renderLinkedRefsBlock(context.linkedRefs, "pull_request"));
+    return blocks.join("\n\n");
   }
 
-  private withPreamble(core: string): string {
-    if (this.preamble.length === 0) {
-      return core;
-    }
-    return `${this.preamble}\n\n${core}`;
-  }
-
-  private appendAdditionalInstructions(
-    lines: string[],
+  private renderUserAdditional(
     additional: string | undefined,
-  ): void {
-    if (additional === undefined || additional.length === 0) {
-      return;
-    }
-
-    lines.push("", "User additional instructions:", additional);
+  ): string | null {
+    if (additional === undefined || additional.length === 0) return null;
+    return `User additional instructions:\n${additional}`;
   }
+}
 
-  private appendBodySection(lines: string[], body: string): void {
-    lines.push("", "Body:", body);
-  }
+function renderBodyBlock(body: string): string {
+  return `Body:\n${body}`;
+}
 
-  private appendCommentsSection(lines: string[], comments: GitHubComment[]): void {
-    lines.push(
-      "",
-      "Comments:",
-      ...(comments.length > 0
-        ? comments.map((comment) => `- ${comment.author}: ${comment.body}`)
-        : ["- none"]),
-    );
-  }
+function renderCommentsBlock(comments: GitHubComment[]): string {
+  const lines =
+    comments.length > 0
+      ? comments.map((comment) => `- ${comment.author}: ${comment.body}`)
+      : ["- none"];
+  return ["Comments:", ...lines].join("\n");
+}
 
-  private appendLinkedRefsSection(
-    lines: string[],
-    linkedRefs: LinkedRefs,
-    sourceKind: "issue" | "pull_request",
-  ): void {
-    const closesHeader =
-      sourceKind === "issue"
-        ? "Linked PRs (closes):"
-        : "Linked Issues (closes):";
+function renderLinkedRefsBlock(
+  linkedRefs: LinkedRefs,
+  sourceKind: "issue" | "pull_request",
+): string {
+  const closesHeader =
+    sourceKind === "issue"
+      ? "Linked PRs (closes):"
+      : "Linked Issues (closes):";
 
-    lines.push(
-      "",
-      closesHeader,
-      ...(linkedRefs.closes.length > 0
-        ? linkedRefs.closes.map(formatLinkedRefEntry)
-        : ["- none"]),
-    );
+  const closesLines =
+    linkedRefs.closes.length > 0
+      ? linkedRefs.closes.map(formatLinkedRefEntry)
+      : ["- none"];
 
-    if (linkedRefs.bodyMentions.length > 0) {
-      lines.push(
-        "",
+  const sections: string[] = [[closesHeader, ...closesLines].join("\n")];
+
+  if (linkedRefs.bodyMentions.length > 0) {
+    sections.push(
+      [
         "Referenced (body mentions):",
         ...linkedRefs.bodyMentions.map(formatLinkedRefEntry),
-      );
-    }
+      ].join("\n"),
+    );
   }
+
+  return sections.join("\n\n");
 }
 
 function formatLinkedRefEntry(entry: LinkedRefEntry): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,6 @@ export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
 
   const promptAssets = await loadPromptAssets({
     promptsDir: path.join(runnerRoot, "definitions", "prompts"),
-    personaName: "architecture",
   });
 
   const daemon = new RunnerDaemon({

--- a/src/infra/instructions/instruction-loader.ts
+++ b/src/infra/instructions/instruction-loader.ts
@@ -14,6 +14,7 @@ interface RawInstructionDefinition {
   source_kind: InstructionDefinition["sourceKind"];
   mode: InstructionDefinition["mode"];
   workflow: InstructionDefinition["workflow"];
+  persona: string;
   context?: Record<string, boolean>;
   permissions: {
     code_read: boolean;
@@ -67,6 +68,25 @@ function mapPermissions(
   };
 }
 
+async function readGuidanceIfPresent(
+  definitionsDir: string,
+  instructionId: string,
+): Promise<string | undefined> {
+  const guidancePath = path.resolve(definitionsDir, `${instructionId}.md`);
+  try {
+    const content = await readFile(guidancePath, "utf8");
+    return content.trim();
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
 export async function loadInstructionDefinition({
   definitionsDir,
   instructionId,
@@ -75,12 +95,22 @@ export async function loadInstructionDefinition({
   const fileContents = await readFile(filePath, "utf8");
   const raw = parse(fileContents) as RawInstructionDefinition;
 
+  if (typeof raw.persona !== "string" || raw.persona.length === 0) {
+    throw new Error(
+      `Instruction ${instructionId} is missing required 'persona' field`,
+    );
+  }
+
+  const guidance = await readGuidanceIfPresent(definitionsDir, instructionId);
+
   return {
     id: raw.id,
     revision: raw.revision,
     sourceKind: raw.source_kind,
     mode: raw.mode,
     workflow: raw.workflow,
+    persona: raw.persona,
+    ...(guidance !== undefined ? { guidance } : {}),
     context: mapContext(raw.context),
     permissions: mapPermissions(raw.permissions),
     githubActions: raw.github_actions,

--- a/src/infra/prompts/prompt-asset-loader.ts
+++ b/src/infra/prompts/prompt-asset-loader.ts
@@ -1,31 +1,47 @@
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import type { ExecutionMode } from "../../domain/instruction.js";
 import type { ModePolicies } from "../../domain/rules/execution-prompt.js";
 
 export interface PromptAssets {
   commonRules: string;
-  persona: string;
+  personas: Record<string, string>;
   modePolicies: ModePolicies;
 }
 
 export interface LoadPromptAssetsInput {
   promptsDir: string;
-  personaName: string;
 }
 
 const MODE_NAMES: ExecutionMode[] = ["observe", "mutate"];
 
+async function loadPersonas(
+  personasDir: string,
+): Promise<Record<string, string>> {
+  const entries = await readdir(personasDir);
+  const mdFiles = entries.filter((name) => name.endsWith(".md"));
+
+  if (mdFiles.length === 0) {
+    throw new Error(`No persona files found in ${personasDir}`);
+  }
+
+  const loaded = await Promise.all(
+    mdFiles.map(async (file) => {
+      const name = file.replace(/\.md$/, "");
+      const content = await readFile(path.resolve(personasDir, file), "utf8");
+      return [name, content.trim()] as const;
+    }),
+  );
+
+  return Object.fromEntries(loaded);
+}
+
 export async function loadPromptAssets({
   promptsDir,
-  personaName,
 }: LoadPromptAssetsInput): Promise<PromptAssets> {
-  const [commonRules, persona, modeContents] = await Promise.all([
+  const [commonRules, personas, modeContents] = await Promise.all([
     readFile(path.resolve(promptsDir, "_common", "work-rules.md"), "utf8"),
-    readFile(
-      path.resolve(promptsDir, "personas", `${personaName}.md`),
-      "utf8",
-    ),
+    loadPersonas(path.resolve(promptsDir, "personas")),
     Promise.all(
       MODE_NAMES.map(async (mode) =>
         [
@@ -45,7 +61,7 @@ export async function loadPromptAssets({
 
   return {
     commonRules: commonRules.trim(),
-    persona: persona.trim(),
+    personas,
     modePolicies,
   };
 }

--- a/src/services/execution-service.ts
+++ b/src/services/execution-service.ts
@@ -33,7 +33,7 @@ export class ExecutionService {
   constructor(private readonly dependencies: ExecutionServiceDependencies) {
     this.promptBuilder = new ExecutionPromptBuilder({
       commonRules: dependencies.promptAssets.commonRules,
-      persona: dependencies.promptAssets.persona,
+      personas: dependencies.promptAssets.personas,
       modePolicies: dependencies.promptAssets.modePolicies,
     });
   }

--- a/tests/unit/enqueue-service.test.ts
+++ b/tests/unit/enqueue-service.test.ts
@@ -9,6 +9,7 @@ const issueImplementInstruction: InstructionDefinition = {
   sourceKind: "issue",
   mode: "mutate",
   workflow: "mutate",
+  persona: "implementation",
   context: {
     includeIssueBody: true,
     includeIssueComments: true,

--- a/tests/unit/execution-prompt-builder.test.ts
+++ b/tests/unit/execution-prompt-builder.test.ts
@@ -35,6 +35,7 @@ const observeInstruction: InstructionDefinition = {
   sourceKind: "issue",
   mode: "observe",
   workflow: "observe",
+  persona: "architecture",
   context: {},
   permissions: {
     codeRead: true,
@@ -55,6 +56,7 @@ const mutateInstruction: InstructionDefinition = {
   id: "issue-implement",
   mode: "mutate",
   workflow: "mutate",
+  persona: "implementation",
   permissions: {
     codeRead: true,
     codeWrite: true,
@@ -70,7 +72,12 @@ const modePolicies: ModePolicies = {
   mutate: "- Mode: mutate\n- MUTATE-MARKER\n- PUSH-FAILURE-MARKER",
 };
 
-const emptyAssets = { commonRules: "", persona: "", modePolicies };
+const personas: Record<string, string> = {
+  architecture: "",
+  implementation: "",
+};
+
+const emptyAssets = { commonRules: "", personas, modePolicies };
 
 describe("ExecutionPromptBuilder", () => {
   test("observe prompts inject the observe mode policy under Policy:", () => {
@@ -104,10 +111,13 @@ describe("ExecutionPromptBuilder", () => {
     );
   });
 
-  test("prepends common rules and persona before the instruction core", () => {
+  test("prepends common rules and the instruction's persona before the instruction core", () => {
     const prompt = new ExecutionPromptBuilder({
       commonRules: "# Common Work Rules\nFollow them.",
-      persona: "# Architecture Persona\nReason in layers.",
+      personas: {
+        architecture: "# Architecture Persona\nReason in layers.",
+        implementation: "# Implementation Persona\nWrite code.",
+      },
       modePolicies,
     }).build({
       task: baseTask,
@@ -129,6 +139,85 @@ describe("ExecutionPromptBuilder", () => {
     assert.ok(
       personaIndex < instructionIndex,
       "persona should precede instruction core",
+    );
+    assert.ok(
+      !prompt.includes("Implementation Persona"),
+      "non-selected personas must not leak into the prompt",
+    );
+  });
+
+  test("selects persona by instruction.persona, not a fixed name", () => {
+    const prompt = new ExecutionPromptBuilder({
+      commonRules: "",
+      personas: {
+        architecture: "ARCH-MARKER",
+        implementation: "IMPL-MARKER",
+      },
+      modePolicies,
+    }).build({
+      task: baseTask,
+      instruction: mutateInstruction,
+      context: issueContext,
+    });
+
+    assert.ok(prompt.includes("IMPL-MARKER"));
+    assert.ok(!prompt.includes("ARCH-MARKER"));
+  });
+
+  test("throws on unknown persona name", () => {
+    const builder = new ExecutionPromptBuilder({
+      commonRules: "",
+      personas: { architecture: "x" },
+      modePolicies,
+    });
+
+    assert.throws(
+      () =>
+        builder.build({
+          task: baseTask,
+          instruction: { ...observeInstruction, persona: "no-such-persona" },
+          context: issueContext,
+        }),
+      /Unknown persona 'no-such-persona'/,
+    );
+  });
+
+  test("appends 'Instruction guidance:' section when instruction has guidance", () => {
+    const prompt = new ExecutionPromptBuilder(emptyAssets).build({
+      task: baseTask,
+      instruction: {
+        ...mutateInstruction,
+        guidance: "- Include `Closes #N` in the PR body.",
+      },
+      context: issueContext,
+    });
+
+    const policyIndex = prompt.indexOf("Policy:");
+    const guidanceIndex = prompt.indexOf("Instruction guidance:");
+    const bodyIndex = prompt.indexOf("Linked PRs (closes):");
+
+    assert.notEqual(guidanceIndex, -1, "guidance section must appear");
+    assert.ok(
+      policyIndex < guidanceIndex,
+      "guidance should follow Policy section",
+    );
+    assert.ok(
+      guidanceIndex < bodyIndex,
+      "guidance should precede data sections",
+    );
+    assert.match(prompt, /Instruction guidance:\n- Include `Closes #N`/);
+  });
+
+  test("omits guidance section entirely when instruction has no guidance", () => {
+    const prompt = new ExecutionPromptBuilder(emptyAssets).build({
+      task: baseTask,
+      instruction: observeInstruction,
+      context: issueContext,
+    });
+
+    assert.ok(
+      !prompt.includes("Instruction guidance:"),
+      "guidance section must be omitted when not provided",
     );
   });
 

--- a/tests/unit/execution-service.test.ts
+++ b/tests/unit/execution-service.test.ts
@@ -14,6 +14,7 @@ const observeInstruction: InstructionDefinition = {
   sourceKind: "issue",
   mode: "observe",
   workflow: "observe",
+  persona: "architecture",
   context: {
     includeIssueBody: true,
     includeIssueComments: true,
@@ -36,6 +37,7 @@ const mutateInstruction: InstructionDefinition = {
   sourceKind: "issue",
   mode: "mutate",
   workflow: "mutate",
+  persona: "implementation",
   context: { includeIssueBody: true, includeIssueComments: true },
   permissions: {
     codeRead: true,
@@ -55,6 +57,7 @@ const prImplementInstruction: InstructionDefinition = {
   sourceKind: "pull_request",
   mode: "mutate",
   workflow: "pr_implement",
+  persona: "implementation",
   context: {
     includePrBody: true,
     includePrComments: true,
@@ -246,7 +249,7 @@ function buildFixture(options: BuildOptions = {}): Fixture {
     },
     promptAssets: {
       commonRules: "",
-      persona: "",
+      personas: { architecture: "", implementation: "" },
       modePolicies: {
         observe: "- Mode: observe",
         mutate: "- Mode: mutate",

--- a/tests/unit/headless-command-agent-runner.test.ts
+++ b/tests/unit/headless-command-agent-runner.test.ts
@@ -16,6 +16,7 @@ const instruction: InstructionDefinition = {
   sourceKind: "issue",
   mode: "observe",
   workflow: "observe",
+  persona: "architecture",
   context: {},
   permissions: {
     codeRead: true,

--- a/tests/unit/instruction-loader.test.ts
+++ b/tests/unit/instruction-loader.test.ts
@@ -86,6 +86,40 @@ describe("loadInstructionDefinition", () => {
     );
   });
 
+  test("persona field is required and read from yaml", async () => {
+    const review = await loadInstructionDefinition({
+      definitionsDir,
+      instructionId: "issue-initial-review",
+    });
+    const implement = await loadInstructionDefinition({
+      definitionsDir,
+      instructionId: "issue-implement",
+    });
+
+    assert.equal(review.persona, "architecture");
+    assert.equal(implement.persona, "implementation");
+  });
+
+  test("guidance is loaded from sibling <id>.md when present", async () => {
+    const implement = await loadInstructionDefinition({
+      definitionsDir,
+      instructionId: "issue-implement",
+    });
+    assert.ok(
+      typeof implement.guidance === "string" && implement.guidance.length > 0,
+      "issue-implement should have sibling guidance md",
+    );
+    assert.match(implement.guidance!, /Closes #/);
+  });
+
+  test("guidance is undefined when no sibling md exists", async () => {
+    const review = await loadInstructionDefinition({
+      definitionsDir,
+      instructionId: "issue-initial-review",
+    });
+    assert.equal(review.guidance, undefined);
+  });
+
   test("workflow field maps observe/mutate/pr_implement from yaml", async () => {
     const observe = await loadInstructionDefinition({
       definitionsDir,

--- a/tests/unit/prompt-asset-loader.test.ts
+++ b/tests/unit/prompt-asset-loader.test.ts
@@ -5,25 +5,31 @@ import { loadPromptAssets } from "../../src/infra/prompts/prompt-asset-loader.js
 const promptsDir = "definitions/prompts";
 
 describe("loadPromptAssets", () => {
-  test("loads common work-rules and the named persona, trimmed", async () => {
-    const assets = await loadPromptAssets({
-      promptsDir,
-      personaName: "architecture",
-    });
+  test("loads common work-rules, trimmed", async () => {
+    const assets = await loadPromptAssets({ promptsDir });
 
     assert.ok(assets.commonRules.length > 0);
-    assert.ok(assets.persona.length > 0);
     assert.match(assets.commonRules, /Common Work Rules/);
-    assert.match(assets.persona, /Architecture Persona/);
     assert.equal(assets.commonRules, assets.commonRules.trim());
-    assert.equal(assets.persona, assets.persona.trim());
+  });
+
+  test("loads every persona file from personas/ as a name → trimmed-content map", async () => {
+    const assets = await loadPromptAssets({ promptsDir });
+
+    assert.ok("architecture" in assets.personas);
+    assert.ok("implementation" in assets.personas);
+
+    for (const [name, content] of Object.entries(assets.personas)) {
+      assert.ok(content.length > 0, `persona ${name} should be non-empty`);
+      assert.equal(content, content.trim(), `persona ${name} should be trimmed`);
+    }
+
+    assert.match(assets.personas.architecture!, /Architecture Persona/);
+    assert.match(assets.personas.implementation!, /Implementation Persona/);
   });
 
   test("loads observe and mutate mode policies, trimmed", async () => {
-    const assets = await loadPromptAssets({
-      promptsDir,
-      personaName: "architecture",
-    });
+    const assets = await loadPromptAssets({ promptsDir });
 
     assert.ok(assets.modePolicies.observe.length > 0);
     assert.ok(assets.modePolicies.mutate.length > 0);
@@ -47,12 +53,5 @@ describe("loadPromptAssets", () => {
     assert.match(assets.modePolicies.mutate, /non-fast-forward/);
     assert.match(assets.modePolicies.mutate, /protected branch/);
     assert.match(assets.modePolicies.mutate, /auth/);
-  });
-
-  test("rejects when the persona file does not exist", async () => {
-    await assert.rejects(
-      loadPromptAssets({ promptsDir, personaName: "no-such-persona" }),
-      /ENOENT/,
-    );
   });
 });

--- a/tests/unit/runner-daemon.test.ts
+++ b/tests/unit/runner-daemon.test.ts
@@ -11,6 +11,7 @@ const instruction: InstructionDefinition = {
   sourceKind: "issue",
   mode: "observe",
   workflow: "observe",
+  persona: "architecture",
   context: {},
   permissions: {
     codeRead: true,

--- a/tests/unit/scheduler-service.test.ts
+++ b/tests/unit/scheduler-service.test.ts
@@ -10,6 +10,7 @@ const observeInstruction: InstructionDefinition = {
   sourceKind: "issue",
   mode: "observe",
   workflow: "observe",
+  persona: "architecture",
   context: {},
   permissions: {
     codeRead: true,
@@ -31,6 +32,7 @@ const mutateInstruction: InstructionDefinition = {
   sourceKind: "issue",
   mode: "mutate",
   workflow: "mutate",
+  persona: "implementation",
   context: {},
   permissions: {
     codeRead: true,


### PR DESCRIPTION
## 변경의 핵심

각 instruction이 자기 고유의 persona와 (선택) guidance md를 가질 수 있게 됨. 이전에는 모든 instruction이 `architecture` persona를 *전역 하드코딩*으로 공유했고 instruction별 추가 가이드를 넣을 자리가 없었지만, 이제 yaml의 `persona:` 필드로 persona를 선택하고 sibling `<id>.md`로 그 instruction에서만 의미 있는 가이드를 추가할 수 있다. 첫 응용으로 `issue-implement.md`에 `Closes #<source>` 라인 + 리뷰어 친화 PR body 작성 규칙을 박았다.

prompt 조립은 6층(preamble = common+persona / header / policy / guidance / data / user additional)이 코드에서도 명시적인 render 함수로 분리됨.

## 리뷰 포인트

- `src/domain/rules/execution-prompt.ts:39-127` — `build()`가 6단 render 함수로 쪼개졌고 persona는 build 시점에 `personas[instruction.persona]`로 lookup. 알 수 없는 persona 이름이면 즉시 throw해 운영 중 silent fallback을 막음 (`renderPreamble:60`). guidance 섹션은 instruction에 `guidance` 필드가 있을 때만 렌더링되어 기존 instruction의 prompt shape에는 변화 없음. 회귀 검증: `tests/unit/execution-prompt-builder.test.ts`의 unknown-persona throw 테스트 + omit-when-absent 테스트.
- `src/infra/instructions/instruction-loader.ts:71-95` — sibling md를 읽을 때 ENOENT만 무시하고 그 외 fs 에러는 그대로 throw. 권한·인코딩 문제를 silent로 무시했다가 prompt가 비어 나가는 회귀가 가장 큰 위험이라 명시적으로 분기. `persona`는 yaml에 없으면 명시 에러 메시지로 startup-fail.
- `src/infra/prompts/prompt-asset-loader.ts:20-39` — `personas/` 디렉토리를 통째로 스캔해서 `Record<name, content>`로 반환. 디렉토리가 비어 있으면 throw. 새 persona 추가는 md 파일 하나 떨어뜨리는 것으로 끝. 검증: `tests/unit/prompt-asset-loader.test.ts`가 architecture·implementation 양쪽이 들어오는 것까지 확인.

## 의도적으로 안 한 것

- `pr-implement`용 sibling md는 추가하지 않음. PR source의 implement 흐름은 source가 이미 PR이라 `Closes #<N>` 자동 닫기 규칙이 의미 없음 (link할 issue가 별개로 있어야 함). 필요해지면 별도 이슈로.
- 그 외 instruction(`issue-comment-reply`, `issue-initial-review`, `pr-review-comment`)도 sibling md 없음. 현재 persona + mode policy로 충분히 가이드 됨.
- `pr-implement.md`의 reviewer-oriented body shape 가이드 분리. 동일 가이드를 PR source에도 줄지는 사용해보고 결정.

## 트레이드오프

- persona 검증을 *startup*이 아니라 *build 시점*에 하기로 함. 이유: instruction은 lazy하게 id별로 로드되므로 startup에서 모든 persona reference를 검증하려면 instruction 디렉토리 일괄 스캔이 추가로 필요. 한 task가 실패하면 즉시 명확한 에러 메시지가 뜨므로 늦은 검증의 비용이 작다고 판단. 만약 운영에서 persona 오타 등이 잦아지면 startup 검증을 추가하는 게 다음 단계.
- 6층 구조를 *코드에서도* 명시적으로 분리(`renderPreamble/Header/Policy/Guidance/Data/UserAdditional`). 한 함수에 inline하면 더 짧지만, 향후 새 layer(예: per-source-kind metadata)를 추가할 때 어디에 끼워야 하는지가 자명해지는 게 더 가치 있다고 봄.

## Test plan

- [x] `npm run build` (TypeScript strict 통과)
- [x] `npm test` (188 / 188 통과 — 신규 6 테스트: persona lookup 정확성, unknown-persona throw, guidance 섹션 렌더/omit, instruction loader가 sibling md를 ENOENT일 때만 silent skip)
- [ ] 실제 webhook 트리거에서 issue #N 처리 시 prompt에 `Instruction guidance:` 섹션 + `Closes #<N>` 가이드가 박히는지 확인
- [ ] `/claude implement`로 만들어진 PR이 머지될 때 source issue가 자동으로 닫히는지 확인 (이슈 #41이 닫히지 않았던 이번 케이스가 회귀 회피의 동기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)