### PR TITLE
fix(deploy): wait for running tasks to drain before restart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,7 +13,8 @@ that user's home directory; secrets live under `/etc`.
 ## Prerequisites
 
 - Ubuntu host with Node.js >= 20 installed
-- `git` available on `$PATH`
+- `git` and `jq` available on `$PATH` (`apt-get install -y jq` if missing —
+  used by `ops/scripts/deploy.sh` to count running tasks before restart)
 - A GitHub App with:
   - Permissions: Issues (RW), Pull requests (RW), Contents (RW), Metadata (R)
   - Subscribed events: Issues, Issue comment, Pull request review comment
@@ -185,13 +186,21 @@ Code runs on this VM; if you operate from a laptop you can skip it.
   in-flight tasks as failed. The daemon's `notifyTaskFailure` callback
   posts a `Task <id> failed before completion: <summary>` comment to the
   originating issue or PR. Orphaned workspaces under `var/workspaces/`
-  are not cleaned automatically in v1.
+  are not cleaned automatically in v1. Note: `deploy.sh` now waits for
+  running tasks to drain before reset/restart, so the normal push flow
+  no longer trips this path; `recoverRunningTasks` is reserved for actual
+  crashes.
 - Manual deploy: `ssh ubuntu@github-runner 'bash /home/ubuntu/runner-deploy/ops/scripts/deploy.sh'`
-- When deploying a change that bumps an instruction `revision` in
-  `definitions/instructions/*.yaml`, prefer to deploy when the queue is
-  empty (`jq '[.[] | select(.status=="running" or .status=="queued")] | length' var/queue/tasks.json`).
-  In-flight tasks pinned to the old revision will keep running with the
-  old prompt; new tasks pick up the new revision.
+- Deploy waits for `status=="running"` tasks to drain (5s polling) before
+  resetting and restarting. Defaults: timeout 600s
+  (`RUNNER_DEPLOY_IDLE_TIMEOUT_SEC`), polling 5s (`RUNNER_DEPLOY_POLL_SEC`).
+  On timeout the deploy is skipped and the next push retries; set
+  `RUNNER_DEPLOY_FORCE_RESTART=1` to override and accept that the running
+  task will be marked failed by `recoverRunningTasks`. `queued` tasks are
+  unaffected — they survive the restart and resume from the new code.
+  Bumping an instruction `revision` in `definitions/instructions/*.yaml`
+  follows the same flow: in-flight tasks finish on the old revision, new
+  tasks pick up the new one.
 
 ## Recommended GitHub setup (not enforced by code)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -191,12 +191,11 @@ Code runs on this VM; if you operate from a laptop you can skip it.
   no longer trips this path; `recoverRunningTasks` is reserved for actual
   crashes.
 - Manual deploy: `ssh ubuntu@github-runner 'bash /home/ubuntu/runner-deploy/ops/scripts/deploy.sh'`
-- Deploy waits for `status=="running"` tasks to drain (5s polling) before
-  resetting and restarting. Defaults: timeout 600s
-  (`RUNNER_DEPLOY_IDLE_TIMEOUT_SEC`), polling 5s (`RUNNER_DEPLOY_POLL_SEC`).
-  On timeout the deploy is skipped and the next push retries; set
-  `RUNNER_DEPLOY_FORCE_RESTART=1` to override and accept that the running
-  task will be marked failed by `recoverRunningTasks`. `queued` tasks are
+- Deploy waits for `status=="running"` tasks to drain before resetting and
+  restarting (polling every 5s, override via `RUNNER_DEPLOY_POLL_SEC`).
+  The wait has no internal timeout — the GitHub Actions workflow
+  `timeout-minutes` (15) is the only outer bound; if the wait exceeds it,
+  the SSH session is killed and the next push retries. `queued` tasks are
   unaffected — they survive the restart and resume from the new code.
   Bumping an instruction `revision` in `definitions/instructions/*.yaml`
   follows the same flow: in-flight tasks finish on the old revision, new

--- a/ops/scripts/deploy.sh
+++ b/ops/scripts/deploy.sh
@@ -9,7 +9,6 @@ set -euo pipefail
 REPO_ROOT=${REPO_ROOT:-/home/ubuntu/runner-deploy}
 SERVICE=${SERVICE:-oh-my-github-runner.service}
 TASKS_JSON="$REPO_ROOT/var/queue/tasks.json"
-IDLE_TIMEOUT_SEC=${RUNNER_DEPLOY_IDLE_TIMEOUT_SEC:-600}
 POLL_SEC=${RUNNER_DEPLOY_POLL_SEC:-5}
 
 cd "$REPO_ROOT"
@@ -28,28 +27,26 @@ echo "Updating $current -> $remote"
 
 # Wait for running tasks to drain before reset/build/restart. If we restarted
 # while tasks are running, recoverRunningTasks() would mark them as failed.
-# Run this BEFORE git reset so a timeout-skip leaves disk == memory (both at
-# old SHA), letting the next deploy push retry naturally.
-elapsed=0
+# Run this BEFORE git reset so disk and memory stay aligned at the old SHA;
+# if the workflow gets killed mid-wait, the next push retries naturally.
 while [ -f "$TASKS_JSON" ]; do
-  running=$(jq -r '[.[] | select(.status=="running")] | length' "$TASKS_JSON" 2>/dev/null || echo "?")
+  # jq 1.6 returns exit 0 with empty stdout on a zero-byte file (e.g. mid
+  # atomic rewrite), so `|| echo "?"` alone isn't enough — normalize any
+  # non-integer result to "?" so transient corruption falls into the retry
+  # branch instead of a silent break.
+  running=$(jq -r '[.[] | select(.status=="running")] | length' "$TASKS_JSON" 2>/dev/null || true)
+  case "$running" in
+    ''|*[!0-9]*) running="?";;
+  esac
   if [ "$running" = "0" ]; then
     break
   fi
   if [ "$running" = "?" ]; then
     echo "tasks.json read failed transiently; retrying in ${POLL_SEC}s"
-  elif [ "$elapsed" -ge "$IDLE_TIMEOUT_SEC" ]; then
-    if [ "${RUNNER_DEPLOY_FORCE_RESTART:-0}" = "1" ]; then
-      echo "Timed out waiting for $running running task(s); forcing restart per RUNNER_DEPLOY_FORCE_RESTART=1."
-      break
-    fi
-    echo "Timed out (${IDLE_TIMEOUT_SEC}s) with $running running task(s); skipping deploy. Next push will retry."
-    exit 0
   else
-    echo "Waiting: $running task(s) still running (elapsed=${elapsed}s, timeout=${IDLE_TIMEOUT_SEC}s)"
+    echo "Waiting: $running task(s) still running"
   fi
   sleep "$POLL_SEC"
-  elapsed=$((elapsed + POLL_SEC))
 done
 
 git reset --hard "$remote"

--- a/ops/scripts/deploy.sh
+++ b/ops/scripts/deploy.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 
 REPO_ROOT=${REPO_ROOT:-/home/ubuntu/runner-deploy}
 SERVICE=${SERVICE:-oh-my-github-runner.service}
+TASKS_JSON="$REPO_ROOT/var/queue/tasks.json"
+IDLE_TIMEOUT_SEC=${RUNNER_DEPLOY_IDLE_TIMEOUT_SEC:-600}
+POLL_SEC=${RUNNER_DEPLOY_POLL_SEC:-5}
 
 cd "$REPO_ROOT"
 
@@ -22,6 +25,32 @@ if [ "$current" = "$remote" ]; then
 fi
 
 echo "Updating $current -> $remote"
+
+# Wait for running tasks to drain before reset/build/restart. If we restarted
+# while tasks are running, recoverRunningTasks() would mark them as failed.
+# Run this BEFORE git reset so a timeout-skip leaves disk == memory (both at
+# old SHA), letting the next deploy push retry naturally.
+elapsed=0
+while [ -f "$TASKS_JSON" ]; do
+  running=$(jq -r '[.[] | select(.status=="running")] | length' "$TASKS_JSON" 2>/dev/null || echo "?")
+  if [ "$running" = "0" ]; then
+    break
+  fi
+  if [ "$running" = "?" ]; then
+    echo "tasks.json read failed transiently; retrying in ${POLL_SEC}s"
+  elif [ "$elapsed" -ge "$IDLE_TIMEOUT_SEC" ]; then
+    if [ "${RUNNER_DEPLOY_FORCE_RESTART:-0}" = "1" ]; then
+      echo "Timed out waiting for $running running task(s); forcing restart per RUNNER_DEPLOY_FORCE_RESTART=1."
+      break
+    fi
+    echo "Timed out (${IDLE_TIMEOUT_SEC}s) with $running running task(s); skipping deploy. Next push will retry."
+    exit 0
+  else
+    echo "Waiting: $running task(s) still running (elapsed=${elapsed}s, timeout=${IDLE_TIMEOUT_SEC}s)"
+  fi
+  sleep "$POLL_SEC"
+  elapsed=$((elapsed + POLL_SEC))
+done
 
 git reset --hard "$remote"
 # Keep dev deps because tsc (typescript) lives in devDependencies and is


### PR DESCRIPTION
## Summary

Closes #56.

`deploy.sh` restarted the daemon the moment a new SHA landed on `main`. Any task in flight at that moment was marked `failed` by `recoverRunningTasks()` at startup → silent loss (only a `Task <id> failed before completion` comment to the user).

This PR adds an idle-wait loop that polls `var/queue/tasks.json` until `status=="running"` count is 0, then proceeds with reset / build / restart.

### Why the wait sits *before* `git reset --hard` (not after build)

If the wait sat after the build, a workflow-timeout kill would leave disk on the new SHA but memory on the old code; the next push would no-op out via the `current == remote` guard and never restart, requiring manual `systemctl restart`. Placing the wait before `git reset` keeps disk and memory aligned on the old SHA, so the next deploy push retries naturally.

### Knobs

- `RUNNER_DEPLOY_POLL_SEC` — default `5`. Polling interval; mainly useful for tests.
- No internal timeout: `.github/workflows/deploy.yml` `timeout-minutes: 15` is the only outer bound. If a task is genuinely stuck longer than that, the workflow goes red, which is the right alarm tone — the operator needs to look. Adding an internal timeout would mask that signal with a clean exit 0 and force a self-chosen "what counts as stuck" threshold.
- No force-restart override: the only thing it would do is re-introduce the silent-loss path on purpose. If an operator truly needs to ship now, they can mark the running task as failed manually and the next push proceeds.

### Workflow timeout

`.github/workflows/deploy.yml` had `timeout-minutes: 5`. Bumped to 15 so the SSH session can outlast typical wait + build + restart.

### Files

- `ops/scripts/deploy.sh` — idle-wait loop between `git fetch` and `git reset --hard`. Result is normalized to integer-or-`?` (jq 1.6 returns exit 0 with empty stdout on a zero-byte file, so `|| echo "?"` alone wasn't enough — would silently fall into the "Waiting:  task(s)" branch).
- `.github/workflows/deploy.yml` — `timeout-minutes: 5 → 15`.
- `docs/deployment.md` — `jq` added to prerequisites; operational tips updated.

## Tests

Direct shell-level tests of the wait block (helper script byte-for-byte mirrors the loop in `deploy.sh`, verified with `diff`):

| Scenario | Result |
|---|---|
| idle pass (no running tasks) | exits immediately, no `Waiting:` log |
| `tasks.json` missing | `while` skipped, exits immediately |
| 1 running drains after 3s | logs `Waiting: 1 task(s)`, breaks on next poll |
| zero-byte `tasks.json` (mid atomic rewrite) | hits transient-retry branch, self-heals |
| malformed JSON | hits transient-retry branch, self-heals |
| `tasks.json` deleted mid-wait | `while` exits cleanly (operator manual reset path) |
| 2 running, staggered drain | logs `Waiting: 2` → `Waiting: 1` → break |

The zero-byte case caught a bug in the first revision (jq exit 0 with empty stdout silently fell through). Fix: normalize non-integer result to `?` via `case` pattern.

## Out of scope (deferred)

- Graceful drain (SIGTERM-aware daemon that stops picking up new tasks during shutdown) — 5s polling race is tolerable until a real loss is observed.
- After #55 (task-per-file queue) lands, the `jq` call collapses to `find var/queue/running -maxdepth 1 -type f | wc -l`. One-line follow-up at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)