### PR TITLE
ci: add Test workflow for PRs and pushes to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm test


### PR DESCRIPTION
Runs `npm ci`, `npm run build`, and `npm test` on Ubuntu / Node 20 on every pull_request to main and on direct pushes to main.

Concurrency group is keyed on `github.ref` so superseding pushes to the same branch cancel in-flight runs. Existing `Deploy` workflow is unaffected.