### PR TITLE
refactor(toolkit): hide tool routing from strategies

### DIFF
--- a/src/services/toolkit.ts
+++ b/src/services/toolkit.ts
@@ -201,7 +201,7 @@ class ToolkitImpl implements Toolkit {
         this.cachedContext,
       );
       const result = await this.options.toolRegistry
-        .resolve(opts.tool)
+        .resolve(this.task.tool)
         .run({
           task: this.task,
           workspacePath: this.active.path,

--- a/src/strategies/issue-comment-reply.ts
+++ b/src/strategies/issue-comment-reply.ts
@@ -16,7 +16,6 @@ export const issueCommentReplyStrategy: Strategy = {
 
     signal.throwIfAborted();
     const result = await tk.ai.run({
-      tool: task.tool,
       prompt: [
         { kind: "file", path: "_common/work-rules" },
         { kind: "file", path: "personas/architecture" },

--- a/src/strategies/issue-implement.ts
+++ b/src/strategies/issue-implement.ts
@@ -16,7 +16,6 @@ export const issueImplementStrategy: Strategy = {
 
     signal.throwIfAborted();
     const result = await tk.ai.run({
-      tool: task.tool,
       prompt: [
         { kind: "file", path: "_common/work-rules" },
         { kind: "file", path: "personas/implementation" },

--- a/src/strategies/issue-initial-review.ts
+++ b/src/strategies/issue-initial-review.ts
@@ -33,7 +33,6 @@ export const issueInitialReviewStrategy: Strategy = {
     for (const persona of PERSONAS) {
       signal.throwIfAborted();
       const result = await tk.ai.run({
-        tool: task.tool,
         prompt: [
           { kind: "file", path: "_common/work-rules" },
           { kind: "file", path: `personas/${persona.id}` },

--- a/src/strategies/pr-implement.ts
+++ b/src/strategies/pr-implement.ts
@@ -22,7 +22,6 @@ export const prImplementStrategy: Strategy = {
 
     signal.throwIfAborted();
     const result = await tk.ai.run({
-      tool: task.tool,
       prompt: [
         { kind: "file", path: "_common/work-rules" },
         { kind: "file", path: "personas/implementation" },

--- a/src/strategies/pr-review-comment.ts
+++ b/src/strategies/pr-review-comment.ts
@@ -22,7 +22,6 @@ export const prReviewCommentStrategy: Strategy = {
 
     signal.throwIfAborted();
     const result = await tk.ai.run({
-      tool: task.tool,
       prompt: [
         { kind: "file", path: "_common/work-rules" },
         { kind: "file", path: "personas/architecture" },

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -17,7 +17,6 @@ export type PromptFragment =
   | { kind: "user"; text: string };
 
 export interface AiRunOptions {
-  tool: string;
   prompt: readonly PromptFragment[];
   allowedTools?: readonly string[];
   disallowedTools?: readonly string[];


### PR DESCRIPTION
## Summary

Strategies declare their required tool once in `policies.tool`. Reading `task.tool` again inside `run()` to pass into `tk.ai.run` was redundant and left it ambiguous which field is the source of truth.

- Drop `tool` from `AiRunOptions`.
- `Toolkit.ai.run` now resolves the runner via `this.task.tool` internally.
- All five strategies lose the `tool: task.tool,` line — the `tool` keyword no longer appears anywhere in strategy `run` bodies.

`task.tool` itself stays on the record (still used by the scheduler's paused-tool check, queue persistence, sticky comment display, and now toolkit's internal routing). The change is strategy-author-facing only.

## Test plan
- [x] `npm test` (156 pass / 0 fail)
- [x] `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)