### PR TITLE
docs(framework): add hint-form guide for strategy authors

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1,0 +1,39 @@
+# Framework guide
+
+Hint sheet for code that isn't self-evident. Types and signatures live in code — see `src/strategies/types.ts` for the contract.
+
+## Model
+
+- `enqueue (webhook) → FS queue → daemon → strategy.run(task, toolkit, signal)`
+- You write a **strategy**. The framework owns enqueue/queue/daemon/toolkit/tool routing.
+- Strategy uses **only** the toolkit. Importing from `src/infra/**` is a layering break.
+
+## Add an instruction
+
+1. `src/strategies/<id>.ts` — implement `Strategy` (`src/strategies/types.ts`).
+2. Register in the Map at `src/strategies/index.ts` (key MUST equal the `instructionId` used at enqueue).
+3. If a webhook event should produce this id, wire it in `src/services/event-dispatcher.ts`.
+
+## Add an AI tool
+
+1. `<NAME>_COMMAND` env var (binary path).
+2. `definitions/tools/<name>.yaml` (descriptor). Rate-limit detection wraps the runner automatically.
+
+## Strategy invariants
+
+- Call `tk.workspace.prepare*` and `tk.github.fetchContext` **before** `tk.ai.run`. Out of order = runtime failure.
+- Call `signal.throwIfAborted()` between awaits, otherwise `supersede` can't unwind cleanly.
+- Hold workspaces with `await using` — disposal cleans the branch and tool artifacts.
+- Declare the tool once in `policies.tool`. Don't read `task.tool` from inside `run()` — the toolkit routes for you.
+
+## Prompt fragments
+
+- Live under `definitions/prompts/{_common,personas,modes,guidance}/<name>.md`.
+- Strategies reference them by string path (`{ kind: "file", path: "personas/architecture" }`). Mistype = runtime error.
+
+## `var/` layout (runtime state, written by daemon)
+
+- `queue/`        — task records (one file per task; directory encodes status)
+- `logs/`         — per-task log files
+- `repos/`        — bare clones (cache)
+- `workspaces/`   — per-task work dirs; janitor cleans orphans on boot

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -38,6 +38,7 @@ export interface TaskRecord {
   repo: RepoRef;
   source: SourceRef;
   instructionId: string;
+  /** Snapshot of the strategy's `policies.tool` at enqueue. Strategies must not read this — toolkit routes ai.run. */
   tool: string;
   additionalInstructions?: string;
   status: TaskStatus;

--- a/src/services/toolkit.ts
+++ b/src/services/toolkit.ts
@@ -201,7 +201,7 @@ class ToolkitImpl implements Toolkit {
         this.cachedContext,
       );
       const result = await this.options.toolRegistry
-        .resolve(opts.tool)
+        .resolve(this.task.tool)
         .run({
           task: this.task,
           workspacePath: this.active.path,

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -5,6 +5,7 @@ import { prImplementStrategy } from "./pr-implement.js";
 import { prReviewCommentStrategy } from "./pr-review-comment.js";
 import type { Strategy } from "./types.js";
 
+// Map key MUST equal `task.instructionId` produced at enqueue.
 export const strategies: ReadonlyMap<string, Strategy> = new Map<
   string,
   Strategy

--- a/src/strategies/issue-comment-reply.ts
+++ b/src/strategies/issue-comment-reply.ts
@@ -16,7 +16,6 @@ export const issueCommentReplyStrategy: Strategy = {
 
     signal.throwIfAborted();
     const result = await tk.ai.run({
-      tool: task.tool,
       prompt: [
         { kind: "file", path: "_common/work-rules" },
         { kind: "file", path: "personas/architecture" },

--- a/src/strategies/issue-implement.ts
+++ b/src/strategies/issue-implement.ts
@@ -16,7 +16,6 @@ export const issueImplementStrategy: Strategy = {
 
     signal.throwIfAborted();
     const result = await tk.ai.run({
-      tool: task.tool,
       prompt: [
         { kind: "file", path: "_common/work-rules" },
         { kind: "file", path: "personas/implementation" },

--- a/src/strategies/issue-initial-review.ts
+++ b/src/strategies/issue-initial-review.ts
@@ -33,7 +33,6 @@ export const issueInitialReviewStrategy: Strategy = {
     for (const persona of PERSONAS) {
       signal.throwIfAborted();
       const result = await tk.ai.run({
-        tool: task.tool,
         prompt: [
           { kind: "file", path: "_common/work-rules" },
           { kind: "file", path: `personas/${persona.id}` },

--- a/src/strategies/pr-implement.ts
+++ b/src/strategies/pr-implement.ts
@@ -22,7 +22,6 @@ export const prImplementStrategy: Strategy = {
 
     signal.throwIfAborted();
     const result = await tk.ai.run({
-      tool: task.tool,
       prompt: [
         { kind: "file", path: "_common/work-rules" },
         { kind: "file", path: "personas/implementation" },

--- a/src/strategies/pr-review-comment.ts
+++ b/src/strategies/pr-review-comment.ts
@@ -22,7 +22,6 @@ export const prReviewCommentStrategy: Strategy = {
 
     signal.throwIfAborted();
     const result = await tk.ai.run({
-      tool: task.tool,
       prompt: [
         { kind: "file", path: "_common/work-rules" },
         { kind: "file", path: "personas/architecture" },

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -17,7 +17,6 @@ export type PromptFragment =
   | { kind: "user"; text: string };
 
 export interface AiRunOptions {
-  tool: string;
   prompt: readonly PromptFragment[];
   allowedTools?: readonly string[];
   disallowedTools?: readonly string[];


### PR DESCRIPTION
## Summary

> Stacked on top of #81. Once #81 merges, this PR's diff narrows to docs only.

One-page hint sheet at `docs/framework.md` covering only what isn't self-evident from code:
- Service shape (enqueue → queue → daemon → strategy)
- Where to plug new instructions / new AI tools (file pointers)
- Strategy runtime invariants the toolkit enforces
- Prompt fragment naming conventions
- `var/` layout

Plus two inline pointers at easy-to-misread boundaries:
- `TaskRecord.tool` — snapshot, strategies must not read.
- `strategies/index.ts` Map — key equals `instructionId`.

Types and signatures stay in code; the doc is hint-form (each section ends in a code path).

## Test plan
- [x] `npx tsc --noEmit`
- [ ] Render check on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)