### PR TITLE
refactor(strategy): policies.uses + per-call tool selection + system-level fence

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -36,7 +36,7 @@ Allow-list is default-deny; everything not listed is implicitly forbidden. Use `
 - Call `tk.workspace.prepare*` and `tk.github.fetchContext` **before** `tk.ai.run`. Out of order = runtime failure.
 - Call `signal.throwIfAborted()` between awaits, otherwise `supersede` can't unwind cleanly.
 - Hold workspaces with `await using` — disposal cleans the branch and tool artifacts.
-- Declare the tool once in `policies.tool`. Don't read `task.tool` from inside `run()` — the toolkit routes for you.
+- Declare the tools the strategy may use in `policies.uses` (e.g. `{ claude: true, gemini: true }`). The toolkit refuses any `tk.ai.run({ tool })` not in that set; if `policies.uses` has a single tool, `opts.tool` is optional and inferred.
 
 ## Prompt fragments
 

--- a/src/daemon/runner-daemon.ts
+++ b/src/daemon/runner-daemon.ts
@@ -15,6 +15,12 @@ export interface RunnerDaemonDependencies {
     task: TaskRecord,
     signal: AbortSignal,
   ) => Promise<ExecuteResult>;
+  /**
+   * Resolves the set of tool names a task may route to. Production wires
+   * this to `Object.keys(getStrategy(task.instructionId).policies.uses)`.
+   * Tests inject a stub.
+   */
+  toolsForTask: (task: TaskRecord) => readonly string[];
   logStore: LogStore;
   pollIntervalMs: number;
   rateLimit?: RateLimitDispatch;
@@ -135,6 +141,7 @@ export class RunnerDaemon {
     const nextTaskIds = this.dependencies.schedulerService.selectNextTasks({
       tasks,
       pausedTools,
+      toolsForTask: this.dependencies.toolsForTask,
     });
 
     if (nextTaskIds.length === 0) {
@@ -152,8 +159,9 @@ export class RunnerDaemon {
         task.taskId,
       );
 
+      const tools = this.dependencies.toolsForTask(task).join(",");
       console.log(
-        `[daemon] start task=${task.taskId} instruction=${task.instructionId} tool=${task.tool} repo=${task.repo.owner}/${task.repo.name} ${task.source.kind}=${task.source.number}`,
+        `[daemon] start task=${task.taskId} instruction=${task.instructionId} tools=${tools} repo=${task.repo.owner}/${task.repo.name} ${task.source.kind}=${task.source.number}`,
       );
 
       const abort = new AbortController();

--- a/src/domain/queue-task.ts
+++ b/src/domain/queue-task.ts
@@ -11,7 +11,6 @@ export interface QueueTaskInput {
   repo: RepoRef;
   source: SourceRef;
   instructionId: string;
-  tool: string;
   additionalInstructions?: string;
   requestedBy: string;
   priority?: TaskPriority;

--- a/src/domain/rules/scheduling.ts
+++ b/src/domain/rules/scheduling.ts
@@ -4,6 +4,12 @@ export interface SelectNextTasksInput {
   tasks: TaskRecord[];
   maxConcurrency: number;
   pausedTools?: ReadonlySet<string>;
+  /**
+   * Maps a task's instructionId to the set of tool names its strategy
+   * may use. The scheduler defers any queued task whose set intersects
+   * with `pausedTools`.
+   */
+  toolsForTask: (task: TaskRecord) => readonly string[];
 }
 
 // Pure FIFO scheduling against the concurrency budget, skipping any
@@ -28,7 +34,8 @@ export function selectNextTasks(input: SelectNextTasksInput): string[] {
     if (selected.length >= slots) {
       break;
     }
-    if (pausedTools.has(task.tool)) {
+    const taskTools = input.toolsForTask(task);
+    if (taskTools.some((t) => pausedTools.has(t))) {
       continue;
     }
     selected.push(task.taskId);

--- a/src/domain/task.ts
+++ b/src/domain/task.ts
@@ -38,8 +38,6 @@ export interface TaskRecord {
   repo: RepoRef;
   source: SourceRef;
   instructionId: string;
-  /** Snapshot of the strategy's `policies.tool` at enqueue. Strategies must not read this — toolkit routes ai.run. */
-  tool: string;
   additionalInstructions?: string;
   status: TaskStatus;
   priority: TaskPriority;

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,12 +188,15 @@ export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
     promptsDir: path.join(runnerRoot, "definitions", "prompts"),
   });
   const promptRenderer = new PromptRenderer({ fragments: promptFragments });
+  const toolsForTask = (task: TaskRecord): readonly string[] =>
+    Object.keys(getStrategy(task.instructionId).policies.uses);
   const toolkitFactory = new ToolkitFactory({
     githubClient,
     workspaceManager,
     toolRegistry,
     logStore,
     promptRenderer,
+    toolsForTask,
   });
 
   const daemon = new RunnerDaemon({
@@ -205,6 +208,7 @@ export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
         toolkitFactory.create(task, signal),
         signal,
       ),
+    toolsForTask,
     logStore,
     pollIntervalMs,
     rateLimit: {
@@ -341,8 +345,6 @@ export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
   const allowedSenderIds = parseSenderIdAllowlist("ALLOWED_SENDER_IDS");
 
   const dispatcher = new EventDispatcher({
-    resolveStrategyTool: (instructionId) =>
-      getStrategy(instructionId).policies.tool,
     botUserId,
     allowedSenderIds,
   });

--- a/src/infra/queue/file-queue-store.ts
+++ b/src/infra/queue/file-queue-store.ts
@@ -50,7 +50,6 @@ export class FileQueueStore implements QueueStore {
       repo: input.repo,
       source: input.source,
       instructionId: input.instructionId,
-      tool: input.tool,
       ...(input.additionalInstructions !== undefined &&
       input.additionalInstructions.length > 0
         ? { additionalInstructions: input.additionalInstructions }

--- a/src/services/event-dispatcher.ts
+++ b/src/services/event-dispatcher.ts
@@ -50,7 +50,6 @@ export type DispatchAction =
   | {
       kind: "enqueue";
       instructionId: string;
-      tool: string;
       repo: RepoRef;
       source: SourceRef;
       additionalInstructions?: string;
@@ -67,8 +66,6 @@ export type DispatchAction =
     };
 
 export interface EventDispatcherDependencies {
-  /** Resolves the tool a given strategy declares in its policies. */
-  resolveStrategyTool: (instructionId: string) => string;
   botUserId: number;
   allowedSenderIds: ReadonlySet<number>;
   noAiLabel?: string;
@@ -138,7 +135,6 @@ export class EventDispatcher {
     return {
       kind: "enqueue",
       instructionId,
-      tool: this.deps.resolveStrategyTool(instructionId),
       repo: event.repo,
       source: { kind: "issue", number: event.issue.number },
       requestedBy: event.sender.login,
@@ -167,7 +163,6 @@ export class EventDispatcher {
     return {
       kind: "enqueue",
       instructionId,
-      tool: this.deps.resolveStrategyTool(instructionId),
       repo: event.repo,
       source: { kind: "issue", number: event.issue.number },
       requestedBy: event.sender.login,
@@ -221,7 +216,6 @@ export class EventDispatcher {
     return {
       kind: "enqueue",
       instructionId,
-      tool: this.deps.resolveStrategyTool(instructionId),
       repo: event.repo,
       source: { kind: "pull_request", number: event.pr.number },
       requestedBy: event.sender.login,

--- a/src/services/scheduler-service.ts
+++ b/src/services/scheduler-service.ts
@@ -8,6 +8,7 @@ export interface SchedulerServiceOptions {
 export interface SelectNextTasksInput {
   tasks: TaskRecord[];
   pausedTools?: ReadonlySet<string>;
+  toolsForTask: (task: TaskRecord) => readonly string[];
 }
 
 export class SchedulerService {

--- a/src/services/sticky-comment.ts
+++ b/src/services/sticky-comment.ts
@@ -1,10 +1,12 @@
 import type { TaskRecord } from "../domain/task.js";
+import { getStrategy, hasStrategy } from "../strategies/index.js";
 import type { TriggerLocation } from "./event-dispatcher.js";
 
 export interface StickyCommentMeta {
   taskId: string;
   instructionId: string;
-  tool: string;
+  /** Names of tools the strategy may route to (lookup of policies.uses). */
+  tools: readonly string[];
   requestedBy: string;
   trigger: TriggerLocation;
 }
@@ -27,23 +29,36 @@ function describeSource(task: TaskRecord): string {
   return `${task.source.kind === "issue" ? "issue" : "PR"} #${task.source.number}`;
 }
 
+function formatToolsCell(tools: readonly string[]): string {
+  if (tools.length === 0) return "`—`";
+  return tools.map((t) => `\`${t}\``).join(", ");
+}
+
+function lookupTaskTools(task: TaskRecord): readonly string[] {
+  if (!hasStrategy(task.instructionId)) return [];
+  return Object.keys(getStrategy(task.instructionId).policies.uses);
+}
+
 function queuedMetaTable(meta: StickyCommentMeta): string {
+  const toolsLabel = meta.tools.length === 1 ? "tool" : "tools";
   return [
     "| key | value |",
     "|---|---|",
     `| instruction | \`${meta.instructionId}\` |`,
-    `| tool | \`${meta.tool}\` |`,
+    `| ${toolsLabel} | ${formatToolsCell(meta.tools)} |`,
     `| triggered by | @${meta.requestedBy} |`,
     `| trigger | ${describeTrigger(meta.trigger)} |`,
   ].join("\n");
 }
 
 function taskMetaTable(task: TaskRecord): string {
+  const tools = lookupTaskTools(task);
+  const toolsLabel = tools.length === 1 ? "tool" : "tools";
   return [
     "| key | value |",
     "|---|---|",
     `| instruction | \`${task.instructionId}\` |`,
-    `| tool | \`${task.tool}\` |`,
+    `| ${toolsLabel} | ${formatToolsCell(tools)} |`,
     `| triggered by | @${task.requestedBy} |`,
     `| source | ${describeSource(task)} |`,
   ].join("\n");

--- a/src/services/toolkit.ts
+++ b/src/services/toolkit.ts
@@ -20,13 +20,27 @@ export interface ToolkitFactoryOptions {
   toolRegistry: Pick<ToolRegistry, "resolve">;
   logStore: LogStore;
   promptRenderer: PromptRenderer;
+  /**
+   * Resolves the set of tool names a task may route to. Production wires
+   * this to `Object.keys(getStrategy(task.instructionId).policies.uses)`.
+   * The toolkit uses it for two things: validating `ai.run({ tool })`
+   * against the strategy's declared set, and fanning out
+   * `cleanupArtifacts` across every declared tool on workspace dispose.
+   */
+  toolsForTask: (task: TaskRecord) => readonly string[];
 }
 
 export class ToolkitFactory {
   constructor(private readonly options: ToolkitFactoryOptions) {}
 
   create(task: TaskRecord, signal?: AbortSignal): Toolkit {
-    return new ToolkitImpl(task, signal, this.options);
+    const declared = this.options.toolsForTask(task);
+    if (declared.length === 0) {
+      throw new Error(
+        `Strategy for instructionId='${task.instructionId}' declares no tools (policies.uses is empty)`,
+      );
+    }
+    return new ToolkitImpl(task, signal, this.options, declared);
   }
 }
 
@@ -48,6 +62,7 @@ class ToolkitImpl implements Toolkit {
     private readonly task: TaskRecord,
     private readonly signal: AbortSignal | undefined,
     private readonly options: ToolkitFactoryOptions,
+    private readonly declaredTools: readonly string[],
   ) {}
 
   readonly github = {
@@ -178,17 +193,23 @@ class ToolkitImpl implements Toolkit {
     },
   };
 
+  // Fan-out cleanup across every tool the strategy declared. Each
+  // runner's cleanupArtifacts is a no-op when there's nothing to clean,
+  // so iterating over the declared set is safe even for tools that
+  // never actually ran during this task.
   private async cleanupToolArtifacts(workspacePath: string): Promise<void> {
-    try {
-      await this.options.toolRegistry
-        .resolve(this.task.tool)
-        .cleanupArtifacts(workspacePath);
-    } catch (error) {
-      console.warn(
-        `[toolkit] cleanupArtifacts failed for task=${this.task.taskId} tool=${this.task.tool}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
+    for (const toolName of this.declaredTools) {
+      try {
+        await this.options.toolRegistry
+          .resolve(toolName)
+          .cleanupArtifacts(workspacePath);
+      } catch (error) {
+        console.warn(
+          `[toolkit] cleanupArtifacts failed for task=${this.task.taskId} tool=${toolName}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
     }
   }
 
@@ -208,28 +229,37 @@ class ToolkitImpl implements Toolkit {
             "ai.run called before context was fetched - call tk.github.fetchContext first",
         };
       }
+      const toolName = this.resolveTool(opts);
+      if (toolName === null) {
+        return {
+          kind: "failed",
+          errorSummary: `ai.run requires opts.tool when strategy declares multiple tools (declared: ${this.declaredTools.join(", ")})`,
+        };
+      }
+      if (!this.declaredTools.includes(toolName)) {
+        return {
+          kind: "failed",
+          errorSummary: `ai.run: tool '${toolName}' is not in strategy's declared uses (${this.declaredTools.join(", ")})`,
+        };
+      }
       const promptText = this.options.promptRenderer.render(
         opts.prompt,
         this.cachedContext,
       );
-      const result = await this.options.toolRegistry
-        .resolve(this.task.tool)
-        .run({
-          task: this.task,
-          workspacePath: this.active.path,
-          prompt: promptText,
-          installationToken: this.active.installationToken,
-          ...(opts.allowedTools !== undefined
-            ? { allowedTools: opts.allowedTools }
-            : {}),
-          ...(opts.disallowedTools !== undefined
-            ? { disallowedTools: opts.disallowedTools }
-            : {}),
-          ...(opts.timeoutMs !== undefined
-            ? { timeoutMs: opts.timeoutMs }
-            : {}),
-          ...(this.signal !== undefined ? { signal: this.signal } : {}),
-        });
+      const result = await this.options.toolRegistry.resolve(toolName).run({
+        task: this.task,
+        workspacePath: this.active.path,
+        prompt: promptText,
+        installationToken: this.active.installationToken,
+        ...(opts.allowedTools !== undefined
+          ? { allowedTools: opts.allowedTools }
+          : {}),
+        ...(opts.disallowedTools !== undefined
+          ? { disallowedTools: opts.disallowedTools }
+          : {}),
+        ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+        ...(this.signal !== undefined ? { signal: this.signal } : {}),
+      });
       if (result.kind === "succeeded") {
         return { kind: "succeeded", stdout: result.stdout };
       }
@@ -247,6 +277,16 @@ class ToolkitImpl implements Toolkit {
       await this.options.logStore.write(this.task.taskId, message);
     },
   };
+
+  private resolveTool(opts: AiRunOptions): string | null {
+    if (opts.tool !== undefined) {
+      return opts.tool;
+    }
+    if (this.declaredTools.length === 1) {
+      return this.declaredTools[0]!;
+    }
+    return null;
+  }
 
   private makeDisposable(input: {
     path: string;

--- a/src/services/webhook-handler.ts
+++ b/src/services/webhook-handler.ts
@@ -22,6 +22,7 @@ import {
   renderRejection,
   type StickyCommentMeta,
 } from "./sticky-comment.js";
+import { getStrategy } from "../strategies/index.js";
 
 export interface WebhookHandlerDependencies {
   secret: string;
@@ -164,8 +165,9 @@ export class WebhookHandler {
     action: DispatchAction,
   ): void {
     if (action.kind === "enqueue") {
+      const tools = listStrategyTools(action.instructionId).join(",");
       console.log(
-        `[webhook] enqueue delivery=${deliveryId} event=${eventName} instruction=${action.instructionId} tool=${action.tool} repo=${action.repo.owner}/${action.repo.name} ${action.source.kind}=${action.source.number} requestedBy=${action.requestedBy}`,
+        `[webhook] enqueue delivery=${deliveryId} event=${eventName} instruction=${action.instructionId} tools=${tools} repo=${action.repo.owner}/${action.repo.name} ${action.source.kind}=${action.source.number} requestedBy=${action.requestedBy}`,
       );
       return;
     }
@@ -330,7 +332,7 @@ export class WebhookHandler {
     const meta: StickyCommentMeta = {
       taskId,
       instructionId: action.instructionId,
-      tool: action.tool,
+      tools: listStrategyTools(action.instructionId),
       requestedBy: action.requestedBy,
       trigger: action.trigger,
     };
@@ -377,7 +379,6 @@ export class WebhookHandler {
         repo: action.repo,
         source: action.source,
         instructionId: action.instructionId,
-        tool: action.tool,
         requestedBy: action.requestedBy,
         ...(notifications.sticky !== undefined ||
         notifications.trigger !== undefined
@@ -472,6 +473,10 @@ function readSender(
   }
 
   return { id: event.sender.id, login: event.sender.login };
+}
+
+function listStrategyTools(instructionId: string): string[] {
+  return Object.keys(getStrategy(instructionId).policies.uses);
 }
 
 function describeSender(payload: unknown): string {

--- a/src/strategies/issue-comment-reply.ts
+++ b/src/strategies/issue-comment-reply.ts
@@ -5,7 +5,7 @@ import type { Strategy } from "./types.js";
 const TIMEOUT_MS = 1800 * 1000;
 
 export const issueCommentReplyStrategy: Strategy = {
-  policies: { tool: "claude", supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
+  policies: { uses: { claude: true }, supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
   run: async (task, tk, signal) => {
     signal.throwIfAborted();
     await using ws = await tk.workspace.prepareObserve(task);

--- a/src/strategies/issue-implement.ts
+++ b/src/strategies/issue-implement.ts
@@ -5,7 +5,7 @@ import type { Strategy } from "./types.js";
 const TIMEOUT_MS = 3600 * 1000;
 
 export const issueImplementStrategy: Strategy = {
-  policies: { tool: "claude", supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
+  policies: { uses: { claude: true }, supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
   run: async (task, tk, signal) => {
     signal.throwIfAborted();
     const ctx = await tk.github.fetchContext(task);

--- a/src/strategies/issue-initial-review.ts
+++ b/src/strategies/issue-initial-review.ts
@@ -16,7 +16,7 @@ const PER_PERSONA_TIMEOUT_MS = 1800 * 1000;
 const TIMEOUT_MS = PER_PERSONA_TIMEOUT_MS * PERSONAS.length;
 
 export const issueInitialReviewStrategy: Strategy = {
-  policies: { tool: "claude", supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
+  policies: { uses: { claude: true }, supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
   run: async (task, tk, signal) => {
     signal.throwIfAborted();
     await using ws = await tk.workspace.prepareObserve(task);

--- a/src/strategies/pr-implement.ts
+++ b/src/strategies/pr-implement.ts
@@ -5,7 +5,7 @@ import type { Strategy } from "./types.js";
 const TIMEOUT_MS = 3600 * 1000;
 
 export const prImplementStrategy: Strategy = {
-  policies: { tool: "claude", supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
+  policies: { uses: { claude: true }, supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
   run: async (task, tk, signal) => {
     signal.throwIfAborted();
     const ctx = await tk.github.fetchContext(task);

--- a/src/strategies/pr-review-comment.ts
+++ b/src/strategies/pr-review-comment.ts
@@ -5,7 +5,7 @@ import type { Strategy } from "./types.js";
 const TIMEOUT_MS = 1800 * 1000;
 
 export const prReviewCommentStrategy: Strategy = {
-  policies: { tool: "claude", supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
+  policies: { uses: { claude: true }, supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
   run: async (task, tk, signal) => {
     signal.throwIfAborted();
     const ctx = await tk.github.fetchContext(task);

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -17,6 +17,13 @@ export type PromptFragment =
   | { kind: "user"; text: string };
 
 export interface AiRunOptions {
+  /**
+   * Which tool to route this call to. Must be a key of the strategy's
+   * `policies.uses`. May be omitted only when the strategy declares a
+   * single tool (then it's inferred); strategies declaring multiple
+   * tools must specify per call.
+   */
+  tool?: string;
   prompt: readonly PromptFragment[];
   allowedTools?: readonly string[];
   disallowedTools?: readonly string[];
@@ -81,8 +88,14 @@ export type ExecuteResult =
   | { status: "rate_limited"; toolName: string };
 
 export interface StrategyPolicies {
-  /** Tool the dispatcher uses when enqueueing this strategy. */
-  tool: string;
+  /**
+   * Set of tools this strategy may route ai.run calls to. Keys are tool
+   * names (e.g. "claude", "codex", "gemini"); only `true` is allowed as
+   * the value, so writing `{ claude: true }` reads as "uses claude".
+   * The daemon defers a task until ALL tools listed here are clear of
+   * any rate-limit cooldown.
+   */
+  uses: Record<string, true>;
   /** EnqueueService cancels prior active tasks on the same (repo, source). */
   supersedeOnSameSource: boolean;
   /** Per-call ai.run timeout default (replaces yaml `execution.timeout_sec`). */

--- a/tests/integration/issue-opened-flow.test.ts
+++ b/tests/integration/issue-opened-flow.test.ts
@@ -25,7 +25,6 @@ describe("integration: issue-opened webhook produces an enqueued task", () => {
       });
 
       const dispatcher = new EventDispatcher({
-        resolveStrategyTool: () => "claude",
         botUserId: 9999,
         allowedSenderIds: new Set([42, 100, 200]),
       });
@@ -75,7 +74,6 @@ describe("integration: issue-opened webhook produces an enqueued task", () => {
       assert.equal(tasks.length, 1);
       const task = tasks[0]!;
       assert.equal(task.instructionId, "issue-initial-review");
-      assert.equal(task.tool, "claude");
       assert.equal(task.status, "queued");
       assert.deepEqual(task.repo, {
         owner: REPO_OWNER,

--- a/tests/unit/claude-tool-runner.test.ts
+++ b/tests/unit/claude-tool-runner.test.ts
@@ -18,7 +18,6 @@ const task: TaskRecord = {
   repo: { owner: "octo", name: "repo" },
   source: { kind: "issue", number: 100 },
   instructionId: "issue-comment-reply",
-  tool: "claude",
   status: "running",
   priority: "normal",
   requestedBy: "test",

--- a/tests/unit/codex-tool-runner.test.ts
+++ b/tests/unit/codex-tool-runner.test.ts
@@ -19,7 +19,6 @@ const task: TaskRecord = {
   repo: { owner: "octo", name: "repo" },
   source: { kind: "issue", number: 42 },
   instructionId: "issue-comment-reply",
-  tool: "codex",
   status: "running",
   priority: "normal",
   requestedBy: "test",

--- a/tests/unit/enqueue-service.test.ts
+++ b/tests/unit/enqueue-service.test.ts
@@ -34,7 +34,6 @@ describe("EnqueueService", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 100 },
         instructionId: "nope-not-a-real-strategy",
-        tool: "claude",
         requestedBy: "test",
       }),
       /no strategy is registered/i,
@@ -49,7 +48,6 @@ describe("EnqueueService", () => {
           repo: input.repo,
           source: input.source,
           instructionId: input.instructionId,
-          tool: input.tool,
           status: "queued",
           priority: input.priority ?? "normal",
           requestedBy: input.requestedBy,
@@ -79,13 +77,11 @@ describe("EnqueueService", () => {
       repo: { owner: "octo", name: "repo" },
       source: { kind: "issue", number: 100 },
       instructionId: "issue-implement",
-      tool: "claude",
       requestedBy: "test",
     });
 
     assert.equal(task.taskId, "task_1");
     assert.equal(task.status, "queued");
-    assert.equal(task.tool, "claude");
     assert.equal(task.instructionId, "issue-implement");
   });
 
@@ -97,7 +93,6 @@ describe("EnqueueService", () => {
       repo: { owner: "octo", name: "repo" },
       source: { kind: "issue" as const, number: 100 },
       instructionId: "issue-implement",
-      tool: "claude",
       status: "queued" as const,
       priority: "normal" as const,
       requestedBy: "alice",
@@ -111,7 +106,6 @@ describe("EnqueueService", () => {
           repo: input.repo,
           source: input.source,
           instructionId: input.instructionId,
-          tool: input.tool,
           status: "queued",
           priority: "normal",
           requestedBy: input.requestedBy,
@@ -142,7 +136,6 @@ describe("EnqueueService", () => {
       repo: { owner: "octo", name: "repo" },
       source: { kind: "issue", number: 100 },
       instructionId: "issue-implement",
-      tool: "claude",
       requestedBy: "alice",
     });
 

--- a/tests/unit/event-dispatcher.test.ts
+++ b/tests/unit/event-dispatcher.test.ts
@@ -13,7 +13,6 @@ function makeDispatcher(options?: {
   allowedSenderIds?: ReadonlySet<number>;
 }): EventDispatcher {
   return new EventDispatcher({
-    resolveStrategyTool: () => "claude",
     botUserId: options?.botUserId ?? 9999,
     allowedSenderIds: options?.allowedSenderIds ?? new Set([100, 101, 102]),
   });
@@ -58,7 +57,6 @@ describe("EventDispatcher", () => {
     assert.equal(action.kind, "enqueue");
     if (action.kind !== "enqueue") return;
     assert.equal(action.instructionId, "issue-initial-review");
-    assert.equal(action.tool, "claude");
     assert.deepEqual(action.source, { kind: "issue", number: 7 });
     assert.equal(action.requestedBy, "alice");
   });

--- a/tests/unit/file-queue-store.test.ts
+++ b/tests/unit/file-queue-store.test.ts
@@ -21,7 +21,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 100 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
 
@@ -45,14 +44,12 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 100 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
       const different = await store.enqueue({
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 200 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
       // Move `same` to running.
@@ -82,7 +79,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 100 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
 
@@ -110,7 +106,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 100 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
       await store.startTask(old.taskId);
@@ -140,21 +135,18 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 1 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
       const b = await store.enqueue({
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 2 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
       const c = await store.enqueue({
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 3 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
 
@@ -178,7 +170,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 100 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
 
@@ -213,7 +204,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 100 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
 
@@ -255,7 +245,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 100 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
 
@@ -290,7 +279,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 1 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
       await store.startTask(oldDone.taskId);
@@ -300,7 +288,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 2 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
       await store.startTask(oldFailed.taskId);
@@ -327,7 +314,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 3 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
       await store.startTask(recentDone.taskId);
@@ -337,7 +323,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 4 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
 
@@ -367,7 +352,6 @@ describe("FileQueueStore", () => {
         repo: { owner: "octo", name: "repo" },
         source: { kind: "issue", number: 100 },
         instructionId: "issue-implement",
-        tool: "claude",
         requestedBy: "test",
       });
 

--- a/tests/unit/gemini-tool-runner.test.ts
+++ b/tests/unit/gemini-tool-runner.test.ts
@@ -19,7 +19,6 @@ const task: TaskRecord = {
   repo: { owner: "octo", name: "repo" },
   source: { kind: "issue", number: 7 },
   instructionId: "issue-comment-reply",
-  tool: "gemini",
   status: "running",
   priority: "normal",
   requestedBy: "test",

--- a/tests/unit/issue-initial-review-strategy.test.ts
+++ b/tests/unit/issue-initial-review-strategy.test.ts
@@ -17,7 +17,6 @@ const task: TaskRecord = {
   repo: { owner: "octo", name: "repo" },
   source: { kind: "issue", number: 7 },
   instructionId: "issue-initial-review",
-  tool: "claude",
   status: "running",
   priority: "normal",
   requestedBy: "alice",

--- a/tests/unit/runner-daemon.test.ts
+++ b/tests/unit/runner-daemon.test.ts
@@ -10,13 +10,14 @@ function createTask(status: TaskRecord["status"]): TaskRecord {
     repo: { owner: "octo", name: "repo" },
     source: { kind: "issue", number: 100 },
     instructionId: "issue-comment-reply",
-    tool: "claude",
     status,
     priority: "normal",
     requestedBy: "test",
     createdAt: "2026-04-24T00:00:00.000Z",
   };
 }
+
+const stubToolsForTask = (): readonly string[] => ["claude"];
 
 describe("RunnerDaemon", () => {
   test("initializes recovery and processes one queued task", async () => {
@@ -63,6 +64,7 @@ describe("RunnerDaemon", () => {
         pruneTerminalTasks: async () => 0,
       },
       schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      toolsForTask: stubToolsForTask,
       runStrategy: async () => {
         calls.push("execute");
         return { status: "succeeded" };
@@ -123,6 +125,7 @@ describe("RunnerDaemon", () => {
         pruneTerminalTasks: async () => 0,
       },
       schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      toolsForTask: stubToolsForTask,
       runStrategy: async () => {
         calls.push("execute");
         return { status: "rate_limited", toolName: "claude" };
@@ -192,6 +195,7 @@ describe("RunnerDaemon", () => {
         pruneTerminalTasks: async () => 0,
       },
       schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      toolsForTask: stubToolsForTask,
       runStrategy: async () => {
         throw new Error("getSourceContext network failure");
       },
@@ -244,6 +248,7 @@ describe("RunnerDaemon", () => {
         pruneTerminalTasks: async () => 0,
       },
       schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      toolsForTask: stubToolsForTask,
       runStrategy: async () => ({ status: "rate_limited", toolName: "claude" }),
       logStore: {
         write: async () => {},
@@ -299,6 +304,7 @@ describe("RunnerDaemon", () => {
         pruneTerminalTasks: async () => 0,
       },
       schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      toolsForTask: stubToolsForTask,
       runStrategy: async () => ({
         status: "failed",
         errorSummary: "boom",
@@ -359,6 +365,7 @@ describe("RunnerDaemon", () => {
         pruneTerminalTasks: async () => 0,
       },
       schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      toolsForTask: stubToolsForTask,
       runStrategy: async () => ({ status: "succeeded" }),
       logStore: {
         write: async () => {},
@@ -407,6 +414,7 @@ describe("RunnerDaemon", () => {
         pruneTerminalTasks: async () => 0,
       },
       schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      toolsForTask: stubToolsForTask,
       runStrategy: async () => ({
         status: "rate_limited",
         toolName: "claude",
@@ -478,6 +486,7 @@ describe("RunnerDaemon", () => {
         pruneTerminalTasks: async () => 0,
       },
       schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+      toolsForTask: stubToolsForTask,
       runStrategy: async (_task, signal) => {
         signal.addEventListener("abort", () => {
           resolveStrategy?.({

--- a/tests/unit/scheduler-service.test.ts
+++ b/tests/unit/scheduler-service.test.ts
@@ -7,20 +7,20 @@ function createTask(
   taskId: string,
   status: TaskRecord["status"],
   repoName: string,
-  tool: string = "claude",
 ): TaskRecord {
   return {
     taskId,
     repo: { owner: "octo", name: repoName },
     source: { kind: "issue", number: Number(taskId.replace(/\D/g, "")) || 1 },
     instructionId: "issue-comment-reply",
-    tool,
     status,
     priority: "normal",
     requestedBy: "test",
     createdAt: "2026-04-24T00:00:00.000Z",
   };
 }
+
+const claudeOnly = (): readonly string[] => ["claude"];
 
 describe("SchedulerService", () => {
   test("schedules same-repo work concurrently - branch suffix removes the collision", () => {
@@ -31,6 +31,7 @@ describe("SchedulerService", () => {
         createTask("task_running", "running", "repo-a"),
         createTask("task_queued", "queued", "repo-a"),
       ],
+      toolsForTask: claudeOnly,
     });
 
     assert.deepEqual(selected, ["task_queued"]);
@@ -45,9 +46,26 @@ describe("SchedulerService", () => {
         createTask("task_active", "queued", "repo-b"),
       ],
       pausedTools: new Set(["claude"]),
+      toolsForTask: claudeOnly,
     });
 
     assert.deepEqual(selected, []);
+  });
+
+  test("skips a task if any of its declared tools is paused (any-paused = defer)", () => {
+    const scheduler = new SchedulerService({ maxConcurrency: 2 });
+
+    const selected = scheduler.selectNextTasks({
+      tasks: [
+        createTask("task_multi", "queued", "repo-a"),
+        createTask("task_solo", "queued", "repo-b"),
+      ],
+      pausedTools: new Set(["gemini"]),
+      toolsForTask: (task) =>
+        task.taskId === "task_multi" ? ["claude", "gemini"] : ["claude"],
+    });
+
+    assert.deepEqual(selected, ["task_solo"]);
   });
 
   test("fills free slots with executable queued work in created order", () => {
@@ -59,6 +77,7 @@ describe("SchedulerService", () => {
         createTask("task_2", "queued", "repo-a"),
         createTask("task_3", "queued", "repo-b"),
       ],
+      toolsForTask: claudeOnly,
     });
 
     assert.deepEqual(selected, ["task_1", "task_2"]);
@@ -73,6 +92,7 @@ describe("SchedulerService", () => {
         createTask("task_r2", "running", "repo-b"),
         createTask("task_q", "queued", "repo-c"),
       ],
+      toolsForTask: claudeOnly,
     });
 
     assert.deepEqual(selected, []);

--- a/tests/unit/sticky-comment.test.ts
+++ b/tests/unit/sticky-comment.test.ts
@@ -15,7 +15,7 @@ import {
 const meta: StickyCommentMeta = {
   taskId: "task_abc_123",
   instructionId: "issue-initial-review",
-  tool: "claude",
+  tools: ["claude"],
   requestedBy: "alice",
   trigger: { kind: "issue", issueNumber: 7 },
 };
@@ -25,7 +25,6 @@ const task: TaskRecord = {
   repo: { owner: "octo", name: "repo" },
   source: { kind: "issue", number: 7 },
   instructionId: "issue-initial-review",
-  tool: "claude",
   status: "running",
   priority: "normal",
   requestedBy: "alice",
@@ -73,7 +72,6 @@ describe("sticky-comment renderers", () => {
       repo: { owner: "octo", name: "repo" },
       source: { kind: "issue", number: 7 },
       instructionId: "issue-comment-reply",
-      tool: "claude",
       status: "superseded",
       priority: "normal",
       requestedBy: "alice",

--- a/tests/unit/toolkit.test.ts
+++ b/tests/unit/toolkit.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { GitHubSourceContext } from "../../src/domain/github.js";
+import type { GitHubClient } from "../../src/domain/ports/github-client.js";
+import type { LogStore } from "../../src/domain/ports/log-store.js";
+import type { ToolRunner } from "../../src/domain/ports/tool-runner.js";
+import type { WorkspaceManager } from "../../src/domain/ports/workspace-manager.js";
+import type { TaskRecord } from "../../src/domain/task.js";
+import type { ToolRunInput, ToolRunResult } from "../../src/domain/tool.js";
+import type { PromptRenderer } from "../../src/infra/prompts/prompt-renderer.js";
+import { ToolkitFactory } from "../../src/services/toolkit.js";
+import type { ToolRegistry } from "../../src/services/tool-registry.js";
+
+const task: TaskRecord = {
+  taskId: "task_tk_1",
+  repo: { owner: "octo", name: "repo" },
+  source: { kind: "issue", number: 11 },
+  instructionId: "issue-comment-reply",
+  status: "running",
+  priority: "normal",
+  requestedBy: "test",
+  createdAt: "2026-04-30T00:00:00.000Z",
+};
+
+const issueContext: GitHubSourceContext = {
+  kind: "issue",
+  title: "T",
+  body: "",
+  comments: [],
+  linkedRefs: { closes: [], bodyMentions: [] },
+};
+
+interface RunnerCall {
+  toolName: string;
+  input: ToolRunInput;
+}
+
+function buildToolkit(opts: {
+  declared: readonly string[];
+  runners?: Record<string, ToolRunner>;
+}) {
+  const calls: RunnerCall[] = [];
+  const cleanups: string[] = [];
+  const stubRunner = (name: string): ToolRunner => ({
+    run: async (input): Promise<ToolRunResult> => {
+      calls.push({ toolName: name, input });
+      return { kind: "succeeded", stdout: `ok-from-${name}` };
+    },
+    cleanupArtifacts: async (workspacePath) => {
+      cleanups.push(`${name}:${workspacePath}`);
+    },
+  });
+  const runners = opts.runners ?? {
+    claude: stubRunner("claude"),
+    codex: stubRunner("codex"),
+    gemini: stubRunner("gemini"),
+  };
+  const toolRegistry: Pick<ToolRegistry, "resolve"> = {
+    resolve: (name) => {
+      const runner = runners[name];
+      if (runner === undefined) throw new Error(`Unknown tool: ${name}`);
+      return runner;
+    },
+  };
+  const githubClient = {
+    getSourceContext: async () => issueContext,
+    getInstallationAccessToken: async () => "ghs_FAKE",
+    getDefaultBranch: async () => "main",
+    postIssueComment: async () => {
+      throw new Error("not used");
+    },
+    postPullRequestComment: async () => {
+      throw new Error("not used");
+    },
+  } as unknown as GitHubClient;
+  const workspaceManager = {
+    prepareObserveWorkspace: async () => ({
+      workspacePath: "/tmp/ws",
+    }),
+    cleanupWorkspace: async () => {},
+  } as unknown as WorkspaceManager;
+  const promptRenderer = {
+    render: () => "rendered prompt",
+  } as unknown as PromptRenderer;
+  const logStore = {
+    write: async () => {},
+  } as unknown as LogStore;
+
+  const factory = new ToolkitFactory({
+    githubClient,
+    workspaceManager,
+    toolRegistry,
+    logStore,
+    promptRenderer,
+    toolsForTask: () => opts.declared,
+  });
+  return { factory, calls, cleanups };
+}
+
+describe("ToolkitFactory.create", () => {
+  test("throws when strategy declares no tools", () => {
+    const { factory } = buildToolkit({ declared: [] });
+    assert.throws(
+      () => factory.create(task),
+      /declares no tools/i,
+    );
+  });
+});
+
+describe("toolkit.ai.run — single-tool strategy", () => {
+  test("resolves automatically to the only declared tool when opts.tool is omitted", async () => {
+    const { factory, calls } = buildToolkit({ declared: ["claude"] });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    const result = await tk.ai.run({
+      prompt: [{ kind: "literal", text: "hi" }],
+    });
+
+    assert.equal(result.kind, "succeeded");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.toolName, "claude");
+  });
+
+  test("rejects an explicit opts.tool that isn't declared", async () => {
+    const { factory } = buildToolkit({ declared: ["claude"] });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    const result = await tk.ai.run({
+      tool: "gemini",
+      prompt: [{ kind: "literal", text: "hi" }],
+    });
+
+    assert.equal(result.kind, "failed");
+    if (result.kind !== "failed") return;
+    assert.match(result.errorSummary, /not in strategy's declared uses/);
+  });
+});
+
+describe("toolkit.ai.run — multi-tool strategy", () => {
+  test("requires opts.tool to disambiguate", async () => {
+    const { factory } = buildToolkit({ declared: ["claude", "gemini"] });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    const result = await tk.ai.run({
+      prompt: [{ kind: "literal", text: "hi" }],
+    });
+
+    assert.equal(result.kind, "failed");
+    if (result.kind !== "failed") return;
+    assert.match(result.errorSummary, /requires opts\.tool/);
+  });
+
+  test("routes to the requested tool when opts.tool is in declared set", async () => {
+    const { factory, calls } = buildToolkit({
+      declared: ["claude", "gemini"],
+    });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    await tk.ai.run({
+      tool: "gemini",
+      prompt: [{ kind: "literal", text: "first" }],
+    });
+    await tk.ai.run({
+      tool: "claude",
+      prompt: [{ kind: "literal", text: "second" }],
+    });
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0]?.toolName, "gemini");
+    assert.equal(calls[1]?.toolName, "claude");
+  });
+
+  test("rejects an opts.tool outside the declared set", async () => {
+    const { factory } = buildToolkit({ declared: ["claude", "gemini"] });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    const result = await tk.ai.run({
+      tool: "codex",
+      prompt: [{ kind: "literal", text: "hi" }],
+    });
+
+    assert.equal(result.kind, "failed");
+    if (result.kind !== "failed") return;
+    assert.match(result.errorSummary, /not in strategy's declared uses/);
+  });
+});
+
+describe("toolkit cleanup fan-out", () => {
+  test("calls cleanupArtifacts on every declared tool when the workspace disposes", async () => {
+    const { factory, cleanups } = buildToolkit({
+      declared: ["claude", "gemini"],
+    });
+    const tk = factory.create(task);
+
+    {
+      await using ws = await tk.workspace.prepareObserve(task);
+      void ws;
+    }
+
+    assert.deepEqual(cleanups.sort(), [
+      "claude:/tmp/ws",
+      "gemini:/tmp/ws",
+    ]);
+  });
+});

--- a/tests/unit/webhook-handler.test.ts
+++ b/tests/unit/webhook-handler.test.ts
@@ -50,7 +50,6 @@ function buildHarness(options: HarnessOptions = {}): Harness {
   let nextCommentId = 1000;
 
   const dispatcher = new EventDispatcher({
-    resolveStrategyTool: () => "claude",
     botUserId,
     allowedSenderIds: new Set([1, 100, 200]),
   });
@@ -67,7 +66,6 @@ function buildHarness(options: HarnessOptions = {}): Harness {
           repo: input.repo,
           source: input.source,
           instructionId: input.instructionId,
-          tool: input.tool,
           status: "queued" as const,
           priority: "normal" as const,
           requestedBy: input.requestedBy,
@@ -222,7 +220,6 @@ describe("WebhookHandler", () => {
 
     assert.equal(harness.enqueued.length, 1);
     assert.equal(harness.enqueued[0]?.instructionId, "issue-initial-review");
-    assert.equal(harness.enqueued[0]?.tool, "claude");
   });
 
   test("posts a rejection comment for fork PR /omgr implement", async () => {
@@ -406,7 +403,6 @@ describe("WebhookHandler", () => {
   test("enqueue still proceeds when reaction API throws", async () => {
     const enqueued: QueueTaskInput[] = [];
     const dispatcher = new EventDispatcher({
-      resolveStrategyTool: () => "claude",
       botUserId,
       allowedSenderIds: new Set([100]),
     });
@@ -422,7 +418,6 @@ describe("WebhookHandler", () => {
             repo: input.repo,
             source: input.source,
             instructionId: input.instructionId,
-            tool: input.tool,
             status: "queued" as const,
             priority: "normal" as const,
             requestedBy: input.requestedBy,


### PR DESCRIPTION
## Summary

- Strategy가 사용할 도구 집합을 \`policies.uses\` (e.g. \`{ claude: true, gemini: true }\`)로 선언. 한 strategy 안에서 \`tk.ai.run({ tool: 'claude', ... })\`, \`tk.ai.run({ tool: 'gemini', ... })\`처럼 호출별 라우팅 가능
- 시스템 레벨 fence: toolkit이 declared set 기준으로 \`opts.tool\` 검증 — 선언 안 한 도구 호출은 명확한 에러로 즉시 실패. 단일 도구 strategy는 \`opts.tool\` 생략 가능 (자동 inference)
- \`task.tool\` 필드 제거 — strategy registry가 단일 진실 원천. \`EventDispatcher.resolveStrategyTool\`도 함께 사라짐
- Daemon rate-limit 사전 차단: \`policies.uses\`의 키 union 중 **하나라도** cooldown이면 task 보류 (any-paused = defer)
- Workspace dispose 시 cleanup이 declared 도구 전부에 fan-out — 멀티툴 strategy에서 \`.codex/\` \`.gemini/\` 잔여물 정리 보장

## Test plan

- [x] \`npm run build\` 통과
- [x] \`npm run test\` 181 tests pass (toolkit 7개, scheduler multi-tool 1개 신규)
- [x] toolkit 검증 4 케이스 모두 커버: 단일도구 자동 resolve, 단일도구 unknown reject, 멀티툴 \`opts.tool\` 강제, 멀티툴 declared 외 reject
- [ ] staging에서 기존 strategy(전부 단일 claude) 한 사이클 동작 확인 — 행동 변화 0이어야 함

## 후속

멀티툴 strategy의 첫 use case가 이 PR 위에서 자연스럽게 등장 가능. \`policies.uses\` 한 줄 + \`tk.ai.run({ tool })\` 명시만 하면 됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)