### PR TITLE
fix(codex): always run with workspace-write sandbox (closes #95)

### DIFF
--- a/src/infra/tool/codex-tool-runner.ts
+++ b/src/infra/tool/codex-tool-runner.ts
@@ -48,7 +48,7 @@ export class CodexToolRunner implements ToolRunner {
     const args = [
       "exec",
       "--sandbox",
-      pickSandbox(input.allowedTools),
+      "workspace-write",
       "--ephemeral",
       "--skip-git-repo-check",
       "-C",
@@ -97,24 +97,6 @@ export class CodexToolRunner implements ToolRunner {
       blocks.join("\n\n") + "\n",
     );
   }
-}
-
-// Codex's permission model is two layers:
-//   - sandbox mode (FS+net coarse control) via --sandbox flag
-//   - prefix rules (per-shell-command fence) via .codex/rules/*.rules
-// Built-in capabilities like read/edit/write don't have shell rules; they
-// collapse into the sandbox mode. `edit` or `write` in the allow list
-// implies the agent intends to mutate, so we widen the sandbox.
-export function pickSandbox(
-  allowed: readonly string[] | undefined,
-): "read-only" | "workspace-write" {
-  const list = allowed ?? [];
-  for (const item of list) {
-    if (item === "edit" || item === "write") {
-      return "workspace-write";
-    }
-  }
-  return "read-only";
 }
 
 // `shell:<token-prefix>` → `prefix_rule(pattern=[...], decision="...")`.

--- a/src/infra/tool/gemini-tool-runner.ts
+++ b/src/infra/tool/gemini-tool-runner.ts
@@ -53,10 +53,13 @@ export class GeminiToolRunner implements ToolRunner {
     const policyPath = path.join(input.workspacePath, ".gemini", "policy.toml");
     const wrotePolicy = await this.writePolicyFile(policyPath, input);
 
+    // `plan` would be the natural choice for observe-only strategies but
+    // hangs in headless mode in observed gemini-cli versions, so we run
+    // in `yolo` and rely on the policy file for actual fences.
     const args = [
       ...(wrotePolicy ? ["--policy", policyPath] : []),
       "--approval-mode",
-      pickApprovalMode(input.allowedTools),
+      "yolo",
       "--skip-trust",
       "--prompt",
       input.prompt,
@@ -110,16 +113,6 @@ export class GeminiToolRunner implements ToolRunner {
     await this.fs.writeFile(policyPath, blocks.join("\n\n") + "\n");
     return true;
   }
-}
-
-// `--approval-mode plan` is read-only but hangs in headless mode in
-// observed gemini-cli versions, so we always run in `yolo` and rely on
-// the policy file for actual fences. Future versions that fix headless
-// `plan` could let us flip observe-only strategies to plan mode here.
-export function pickApprovalMode(
-  _allowed: readonly string[] | undefined,
-): "yolo" | "auto_edit" | "default" {
-  return "yolo";
 }
 
 // Translate a portable spec entry into a Gemini policy `[[rule]]` block.

--- a/tests/unit/codex-tool-runner.test.ts
+++ b/tests/unit/codex-tool-runner.test.ts
@@ -9,7 +9,6 @@ import type { TaskRecord } from "../../src/domain/task.js";
 import type { ToolRunInput } from "../../src/domain/tool.js";
 import {
   CodexToolRunner,
-  pickSandbox,
   toPrefixRule,
   type CodexFs,
 } from "../../src/infra/tool/codex-tool-runner.js";
@@ -66,19 +65,6 @@ function makeProcessRunner(result?: Partial<RunProcessResult>): {
   };
   return { processRunner, calls };
 }
-
-describe("pickSandbox", () => {
-  test("returns read-only when no write capability is requested", () => {
-    assert.equal(pickSandbox(["read", "grep", "shell:gh"]), "read-only");
-    assert.equal(pickSandbox([]), "read-only");
-    assert.equal(pickSandbox(undefined), "read-only");
-  });
-
-  test("returns workspace-write when edit or write is in the allow list", () => {
-    assert.equal(pickSandbox(["read", "edit"]), "workspace-write");
-    assert.equal(pickSandbox(["write"]), "workspace-write");
-  });
-});
 
 describe("toPrefixRule", () => {
   test("returns null for built-in capabilities", () => {
@@ -137,23 +123,6 @@ describe("CodexToolRunner.run", () => {
       "do the thing",
     ]);
     assert.equal(calls[0]?.cwd, "/tmp/ws");
-  });
-
-  test("picks read-only sandbox when no write capability is allowed", async () => {
-    const { fs } = makeFs();
-    const { processRunner, calls } = makeProcessRunner();
-    const runner = new CodexToolRunner({ command: "codex", processRunner, fs });
-
-    await runner.run({
-      task,
-      workspacePath: "/tmp/ws",
-      prompt: "observe only",
-      allowedTools: ["read", "grep", "shell:gh"],
-    });
-
-    const sandboxFlagIdx = calls[0]?.args?.indexOf("--sandbox");
-    assert.notEqual(sandboxFlagIdx, undefined);
-    assert.equal(calls[0]?.args?.[sandboxFlagIdx! + 1], "read-only");
   });
 
   test("writes a default.rules file with allow + forbidden prefix rules", async () => {

--- a/tests/unit/gemini-tool-runner.test.ts
+++ b/tests/unit/gemini-tool-runner.test.ts
@@ -9,7 +9,6 @@ import type { TaskRecord } from "../../src/domain/task.js";
 import type { ToolRunInput } from "../../src/domain/tool.js";
 import {
   GeminiToolRunner,
-  pickApprovalMode,
   toPolicyBlock,
   type GeminiFs,
 } from "../../src/infra/tool/gemini-tool-runner.js";
@@ -66,14 +65,6 @@ function makeProcessRunner(result?: Partial<RunProcessResult>): {
   };
   return { processRunner, calls };
 }
-
-describe("pickApprovalMode", () => {
-  test("always returns yolo (plan mode hangs in headless)", () => {
-    assert.equal(pickApprovalMode(["read"]), "yolo");
-    assert.equal(pickApprovalMode(["edit"]), "yolo");
-    assert.equal(pickApprovalMode(undefined), "yolo");
-  });
-});
 
 describe("toPolicyBlock", () => {
   test("emits a run_shell_command rule with commandPrefix for shell entries", () => {


### PR DESCRIPTION
## Summary
- Hardcode codex `--sandbox workspace-write` and remove `pickSandbox`. The previous `read-only` choice for observe-mode strategies blocked legitimate `gh issue comment` POSTs at the OS layer, even though `shell:gh` was allowed by prefix rules — that's the silent regression behind #95 after #93 switched `issue-comment-reply` to codex.
- Drop the analogous `pickApprovalMode` from gemini in a separate commit. It already returned `"yolo"` unconditionally, so inline the literal and keep the headless-`plan`-hangs rationale next to the call site. No behavior change for gemini.

## Why this layering
The capability fence is the per-tool prefix-rule / policy file (`.codex/rules/default.rules`, `.gemini/policy.toml`). The sandbox/approval-mode flag was acting as an inconsistent second voice. Workspace-write still bounds file writes to the ephemeral task workspace, so blast radius is unchanged.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 189 tests pass
- [ ] Deploy to runner and verify `/omgr` issue-comment reply actually posts on a live issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)