### PR TITLE
feat(prompt): inject .omgr/ docs into persona prompts

### DIFF
--- a/definitions/prompts/_common/omgr-docs.md
+++ b/definitions/prompts/_common/omgr-docs.md
@@ -1,0 +1,12 @@
+# Repository docs (`.omgr/`)
+
+The target repository may keep agent-facing notes in a top-level `.omgr/` directory. When relevant to the question or task, read them before scanning the codebase. They are optional — absence is normal.
+
+Standard files (read whichever applies):
+
+- `.omgr/overview.md` — what this repo is, key domain concepts
+- `.omgr/architecture.md` — module/layer structure, key abstractions
+- `.omgr/testing.md` — test framework, layout, how to run
+- `.omgr/deployment.md` — how it ships, runs, is observed
+
+Other files under `.omgr/` may exist; treat them as repo-specific notes.

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -43,6 +43,12 @@ Allow-list is default-deny; everything not listed is implicitly forbidden. Use `
 - Live under `definitions/prompts/{_common,personas,modes,guidance}/<name>.md`.
 - Strategies reference them by string path (`{ kind: "file", path: "personas/architecture" }`). Mistype = runtime error.
 
+## Repository docs (`.omgr/`)
+
+- The target repo may keep agent-facing notes under a top-level `.omgr/` directory. Standard files: `overview.md`, `architecture.md`, `testing.md`, `deployment.md`. Other files are allowed.
+- Strategies inject these into a persona's prompt with `{ kind: "omgr-doc", path: ".omgr/<name>.md" }`. The renderer reads from the workspace clone; if the file is absent, the fragment renders as empty (silent skip). Per-strategy mapping (which doc each persona gets) lives in the strategy file.
+- For strategies that should let the persona discover docs on its own (e.g. `issue-comment-reply`), inject the static guide `{ kind: "file", path: "_common/omgr-docs" }` instead — it lists the standard files and lets the persona `read` them as needed.
+
 ## `var/` layout (runtime state, written by daemon)
 
 - `queue/`        — task records (one file per task; directory encodes status)

--- a/src/infra/prompts/prompt-renderer.ts
+++ b/src/infra/prompts/prompt-renderer.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import type {
   GitHubComment,
   GitHubSourceContext,
@@ -21,20 +23,22 @@ export class PromptRenderer {
     this.fragments = options.fragments;
   }
 
-  render(
+  async render(
     fragments: readonly PromptFragment[],
     context: GitHubSourceContext,
-  ): string {
-    return fragments
-      .map((fragment) => this.renderOne(fragment, context))
-      .filter((piece) => piece.length > 0)
-      .join("\n\n");
+    workspacePath: string,
+  ): Promise<string> {
+    const pieces = await Promise.all(
+      fragments.map((fragment) => this.renderOne(fragment, context, workspacePath)),
+    );
+    return pieces.filter((piece) => piece.length > 0).join("\n\n");
   }
 
-  private renderOne(
+  private async renderOne(
     fragment: PromptFragment,
     context: GitHubSourceContext,
-  ): string {
+    workspacePath: string,
+  ): Promise<string> {
     if (fragment.kind === "literal") {
       return fragment.text;
     }
@@ -50,7 +54,25 @@ export class PromptRenderer {
       }
       return content;
     }
+    if (fragment.kind === "omgr-doc") {
+      return readOmgrDoc(workspacePath, fragment.path);
+    }
     return renderContextBlock(fragment.key, context);
+  }
+}
+
+async function readOmgrDoc(
+  workspacePath: string,
+  relPath: string,
+): Promise<string> {
+  try {
+    const content = await readFile(path.join(workspacePath, relPath), "utf8");
+    return content.trim();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "";
+    }
+    throw error;
   }
 }
 

--- a/src/services/toolkit.ts
+++ b/src/services/toolkit.ts
@@ -242,9 +242,10 @@ class ToolkitImpl implements Toolkit {
           errorSummary: `ai.run: tool '${toolName}' is not in strategy's declared uses (${this.declaredTools.join(", ")})`,
         };
       }
-      const promptText = this.options.promptRenderer.render(
+      const promptText = await this.options.promptRenderer.render(
         opts.prompt,
         this.cachedContext,
+        this.active.path,
       );
       const result = await this.options.toolRegistry.resolve(toolName).run({
         task: this.task,

--- a/src/strategies/issue-comment-reply.ts
+++ b/src/strategies/issue-comment-reply.ts
@@ -21,6 +21,7 @@ export const issueCommentReplyStrategy: Strategy = {
         { kind: "file", path: "personas/reply" },
         { kind: "literal", text: header(task, ctx) },
         { kind: "file", path: "modes/observe" },
+        { kind: "file", path: "_common/omgr-docs" },
         { kind: "context", key: "issue-body" },
         { kind: "context", key: "issue-comments" },
         { kind: "context", key: "linked-refs" },

--- a/src/strategies/issue-implement.ts
+++ b/src/strategies/issue-implement.ts
@@ -22,6 +22,8 @@ export const issueImplementStrategy: Strategy = {
         { kind: "literal", text: header(task, ctx) },
         { kind: "file", path: "modes/mutate" },
         { kind: "file", path: "guidance/issue-implement" },
+        { kind: "omgr-doc", path: ".omgr/architecture.md" },
+        { kind: "omgr-doc", path: ".omgr/testing.md" },
         { kind: "context", key: "issue-body" },
         { kind: "context", key: "issue-comments" },
         { kind: "context", key: "linked-refs" },

--- a/src/strategies/issue-initial-review/index.ts
+++ b/src/strategies/issue-initial-review/index.ts
@@ -35,6 +35,7 @@ export const issueInitialReviewStrategy: Strategy = {
             { kind: "file", path: `personas/${persona.id}` },
             { kind: "file", path: "modes/collect-only" },
             { kind: "literal", text: header(task, ctx) },
+            { kind: "omgr-doc", path: persona.omgrDoc },
             { kind: "context", key: "issue-body" },
             { kind: "context", key: "linked-refs" },
             { kind: "user", text: task.additionalInstructions ?? "" },

--- a/src/strategies/issue-initial-review/persona-tool-map.ts
+++ b/src/strategies/issue-initial-review/persona-tool-map.ts
@@ -1,8 +1,8 @@
 export const PERSONAS = [
-  { id: "architect", label: "Architect" },
-  { id: "test", label: "Test" },
-  { id: "ops", label: "Ops" },
-  { id: "maintenance", label: "Maintenance" },
+  { id: "architect", label: "Architect", omgrDoc: ".omgr/architecture.md" },
+  { id: "test", label: "Test", omgrDoc: ".omgr/testing.md" },
+  { id: "ops", label: "Ops", omgrDoc: ".omgr/deployment.md" },
+  { id: "maintenance", label: "Maintenance", omgrDoc: ".omgr/architecture.md" },
 ] as const;
 
 export type PersonaId = (typeof PERSONAS)[number]["id"];

--- a/src/strategies/pr-implement.ts
+++ b/src/strategies/pr-implement.ts
@@ -27,6 +27,8 @@ export const prImplementStrategy: Strategy = {
         { kind: "file", path: "personas/implementation" },
         { kind: "literal", text: header(task, ctx) },
         { kind: "file", path: "modes/mutate" },
+        { kind: "omgr-doc", path: ".omgr/architecture.md" },
+        { kind: "omgr-doc", path: ".omgr/testing.md" },
         { kind: "context", key: "pr-body" },
         { kind: "context", key: "pr-comments" },
         { kind: "context", key: "pr-diff" },

--- a/src/strategies/pr-review-comment.ts
+++ b/src/strategies/pr-review-comment.ts
@@ -27,6 +27,7 @@ export const prReviewCommentStrategy: Strategy = {
         { kind: "file", path: "personas/architect" },
         { kind: "literal", text: header(task, ctx) },
         { kind: "file", path: "modes/observe" },
+        { kind: "omgr-doc", path: ".omgr/architecture.md" },
         { kind: "context", key: "pr-body" },
         { kind: "context", key: "pr-comments" },
         { kind: "context", key: "pr-diff" },

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -14,7 +14,8 @@ export type PromptFragment =
   | { kind: "file"; path: string }
   | { kind: "literal"; text: string }
   | { kind: "context"; key: ContextKey }
-  | { kind: "user"; text: string };
+  | { kind: "user"; text: string }
+  | { kind: "omgr-doc"; path: string };
 
 export interface AiRunOptions {
   /**

--- a/tests/unit/issue-initial-review-strategy.test.ts
+++ b/tests/unit/issue-initial-review-strategy.test.ts
@@ -222,6 +222,55 @@ describe("issueInitialReviewStrategy (parallel personas + publisher)", () => {
     assert.equal(publisherCall.tool, "gemini");
   });
 
+  test("each persona prompt includes its mapped .omgr doc; publisher has none", async () => {
+    const { tk, aiCalls } = makeToolkit({ resultsByPersona: ALL_SUCCEEDED });
+
+    await issueInitialReviewStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    const expectedByPersona: Record<string, string> = {
+      architect: ".omgr/architecture.md",
+      test: ".omgr/testing.md",
+      ops: ".omgr/deployment.md",
+      maintenance: ".omgr/architecture.md",
+    };
+
+    for (const call of aiCalls) {
+      const personaFrag = call.prompt.find(
+        (f) => f.kind === "file" && f.path.startsWith("personas/"),
+      );
+      assert.ok(personaFrag && personaFrag.kind === "file");
+      const personaId = personaFrag.path.replace("personas/", "");
+
+      const omgrDocs = call.prompt.filter((f) => f.kind === "omgr-doc");
+
+      if (personaId === "publisher") {
+        assert.equal(
+          omgrDocs.length,
+          0,
+          "publisher prompt must not include any omgr-doc fragment",
+        );
+        continue;
+      }
+
+      const expected = expectedByPersona[personaId];
+      assert.ok(expected, `unexpected persona '${personaId}'`);
+      assert.equal(
+        omgrDocs.length,
+        1,
+        `persona '${personaId}' should have exactly one omgr-doc fragment`,
+      );
+      assert.equal(
+        omgrDocs[0]?.kind === "omgr-doc" ? omgrDocs[0].path : null,
+        expected,
+        `persona '${personaId}' should map to ${expected}`,
+      );
+    }
+  });
+
   test("publisher rate_limited → fallback comment with appendix only", async () => {
     const { tk, aiCalls, postedIssueComments } = makeToolkit({
       resultsByPersona: ALL_SUCCEEDED,

--- a/tests/unit/prompt-renderer.test.ts
+++ b/tests/unit/prompt-renderer.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile, chmod } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "node:test";
+import type { GitHubSourceContext } from "../../src/domain/github.js";
+import { PromptRenderer } from "../../src/infra/prompts/prompt-renderer.js";
+
+const issueContext: GitHubSourceContext = {
+  kind: "issue",
+  title: "T",
+  body: "issue body text",
+  comments: [{ author: "alice", body: "first comment" }],
+  linkedRefs: { closes: [], bodyMentions: [] },
+};
+
+function makeRenderer(fragments: Record<string, string>): PromptRenderer {
+  return new PromptRenderer({
+    fragments: new Map(Object.entries(fragments)),
+  });
+}
+
+describe("PromptRenderer", () => {
+  test("renders literal/user/file/context fragments in order, joined by blank lines", async () => {
+    const renderer = makeRenderer({
+      "_common/work-rules": "RULES",
+      "personas/architect": "ARCH",
+    });
+
+    const out = await renderer.render(
+      [
+        { kind: "file", path: "_common/work-rules" },
+        { kind: "file", path: "personas/architect" },
+        { kind: "literal", text: "HEADER" },
+        { kind: "context", key: "issue-body" },
+        { kind: "user", text: "do X" },
+      ],
+      issueContext,
+      "/unused-when-no-omgr-doc",
+    );
+
+    assert.equal(
+      out,
+      [
+        "RULES",
+        "ARCH",
+        "HEADER",
+        "Body:\nissue body text",
+        "User additional instructions:\ndo X",
+      ].join("\n\n"),
+    );
+  });
+
+  test("file fragment with unknown path throws", async () => {
+    const renderer = makeRenderer({});
+
+    await assert.rejects(
+      () =>
+        renderer.render(
+          [{ kind: "file", path: "missing/key" }],
+          issueContext,
+          "/tmp",
+        ),
+      /Unknown prompt fragment: 'missing\/key'/,
+    );
+  });
+
+  test("user fragment with empty text is filtered out", async () => {
+    const renderer = makeRenderer({});
+
+    const out = await renderer.render(
+      [
+        { kind: "literal", text: "A" },
+        { kind: "user", text: "" },
+        { kind: "literal", text: "B" },
+      ],
+      issueContext,
+      "/tmp",
+    );
+
+    assert.equal(out, "A\n\nB");
+  });
+});
+
+describe("PromptRenderer omgr-doc", () => {
+  test("reads file content from workspace path", async () => {
+    const ws = await mkdtemp(join(tmpdir(), "renderer-"));
+    try {
+      await mkdir(join(ws, ".omgr"), { recursive: true });
+      await writeFile(
+        join(ws, ".omgr", "architecture.md"),
+        "# Architecture\n\nLayered.\n",
+        "utf8",
+      );
+
+      const renderer = makeRenderer({});
+      const out = await renderer.render(
+        [
+          { kind: "literal", text: "HEAD" },
+          { kind: "omgr-doc", path: ".omgr/architecture.md" },
+          { kind: "literal", text: "TAIL" },
+        ],
+        issueContext,
+        ws,
+      );
+
+      assert.equal(out, "HEAD\n\n# Architecture\n\nLayered.\n\nTAIL");
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  test("missing file is silently skipped (filtered out, no error)", async () => {
+    const ws = await mkdtemp(join(tmpdir(), "renderer-"));
+    try {
+      const renderer = makeRenderer({});
+      const out = await renderer.render(
+        [
+          { kind: "literal", text: "HEAD" },
+          { kind: "omgr-doc", path: ".omgr/architecture.md" },
+          { kind: "literal", text: "TAIL" },
+        ],
+        issueContext,
+        ws,
+      );
+
+      assert.equal(out, "HEAD\n\nTAIL");
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  test("non-ENOENT read error propagates", async () => {
+    const ws = await mkdtemp(join(tmpdir(), "renderer-"));
+    try {
+      // A directory at the doc path triggers EISDIR on read.
+      await mkdir(join(ws, ".omgr"), { recursive: true });
+      await mkdir(join(ws, ".omgr", "architecture.md"), { recursive: true });
+
+      const renderer = makeRenderer({});
+      await assert.rejects(
+        () =>
+          renderer.render(
+            [{ kind: "omgr-doc", path: ".omgr/architecture.md" }],
+            issueContext,
+            ws,
+          ),
+        // Don't pin to a specific code; fs may surface EISDIR or similar.
+        /EISDIR|illegal operation/i,
+      );
+    } finally {
+      await chmod(ws, 0o755).catch(() => {});
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/toolkit.test.ts
+++ b/tests/unit/toolkit.test.ts
@@ -79,8 +79,16 @@ function buildToolkit(opts: {
     }),
     cleanupWorkspace: async () => {},
   } as unknown as WorkspaceManager;
+  const renderCalls: Array<{ workspacePath: string }> = [];
   const promptRenderer = {
-    render: () => "rendered prompt",
+    render: async (
+      _fragments: unknown,
+      _ctx: unknown,
+      workspacePath: string,
+    ) => {
+      renderCalls.push({ workspacePath });
+      return "rendered prompt";
+    },
   } as unknown as PromptRenderer;
   const logStore = {
     write: async () => {},
@@ -94,7 +102,7 @@ function buildToolkit(opts: {
     promptRenderer,
     toolsForTask: () => opts.declared,
   });
-  return { factory, calls, cleanups };
+  return { factory, calls, cleanups, renderCalls };
 }
 
 describe("ToolkitFactory.create", () => {
@@ -202,6 +210,24 @@ describe("toolkit.ai.run — multi-tool strategy", () => {
     assert.equal(result.kind, "failed");
     if (result.kind !== "failed") return;
     assert.match(result.errorSummary, /not in strategy's declared uses/);
+  });
+});
+
+describe("toolkit.ai.run — prompt render wiring", () => {
+  test("forwards active workspace path to PromptRenderer.render", async () => {
+    const { factory, renderCalls } = buildToolkit({ declared: ["claude"] });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    await tk.ai.run({
+      prompt: [{ kind: "literal", text: "hi" }],
+    });
+
+    assert.equal(renderCalls.length, 1);
+    assert.equal(renderCalls[0]?.workspacePath, "/tmp/ws");
   });
 });
 


### PR DESCRIPTION
Closes #96.

## Summary
- New `PromptFragment` kind `omgr-doc`: renderer reads `<workspace>/<path>` (typically `.omgr/<name>.md`); ENOENT → silent skip.
- `PromptRenderer.render` is now async and takes the workspace path; toolkit forwards the active workspace.
- Per-persona/strategy mapping injected directly in each strategy file (no auto-discovery, no glob).

## Mapping
| Strategy | Persona | Doc |
|---|---|---|
| issue-initial-review | architect | `.omgr/architecture.md` |
| issue-initial-review | test | `.omgr/testing.md` |
| issue-initial-review | ops | `.omgr/deployment.md` |
| issue-initial-review | maintenance | `.omgr/architecture.md` |
| issue-initial-review | publisher | — |
| issue-implement | implementation | architecture + testing |
| pr-implement | implementation | architecture + testing |
| pr-review-comment | architect | architecture |
| issue-comment-reply | reply | static `_common/omgr-docs` guide; persona `read`s files on demand |

## Standard `.omgr/` files (target repos opt in)
- `overview.md`
- `architecture.md`
- `testing.md`
- `deployment.md`

Other files are allowed; they just won't be auto-injected.

## Test plan
- [x] `npm run build` (tsc --noEmit) clean
- [x] `npm test` — 197/197 pass
- [x] New `prompt-renderer.test.ts`: present file → content; absent → empty (filtered); EISDIR → throw; existing fragment kinds still render correctly
- [x] `toolkit.test.ts`: render mocked async; new test asserts `this.active.path` is forwarded as workspacePath
- [x] `issue-initial-review-strategy.test.ts`: each persona prompt has its mapped omgr-doc; publisher prompt has none

🤖 Generated with [Claude Code](https://claude.com/claude-code)