### PR TITLE
docs(omgr): add .omgr/ docs for omgr self

### DIFF
--- a/.omgr/architecture.md
+++ b/.omgr/architecture.md
@@ -1,0 +1,48 @@
+# Architecture
+
+TypeScript ESM project. Layered: **domain → services → infra → daemon → cli/index**. Higher layers depend on lower; reverse imports are layering breaks.
+
+## Layers
+
+- `src/domain/` — pure types and rules. No IO. Files: `task.ts`, `github.ts`, `tool.ts`, `queue-task.ts`, `task-status.ts`, `rules/*.ts`, `ports/*.ts`.
+- `src/domain/ports/` — interfaces that infra implements. The seam between business logic and IO. `github-client.ts`, `workspace-manager.ts`, `tool-runner.ts`, `queue-store.ts`, `log-store.ts`, `process-runner.ts`.
+- `src/services/` — orchestration. Composes ports into use cases. `enqueue-service.ts`, `event-dispatcher.ts`, `scheduler-service.ts`, `webhook-handler.ts`, `toolkit.ts`, `tool-registry.ts`, `sticky-comment.ts`.
+- `src/infra/` — adapters that implement the ports. Subdirs by area: `github/`, `queue/`, `logs/`, `tool/`, `workspaces/`, `prompts/`, `webhook/`, `platform/`.
+- `src/strategies/` — one file per instruction id. Each implements `Strategy` (`src/strategies/types.ts`). Use **only** the toolkit; never import from `src/infra/**`. Registered in the Map at `src/strategies/index.ts` (key MUST equal the `instructionId`).
+- `src/daemon/runner-daemon.ts` — owns the queue loop: pulls queued tasks, runs the strategy, transitions status, applies rate-limit pause.
+- `src/index.ts` — composition root. Wires env → infra → services → daemon. The only file that imports from every layer.
+- `src/runtime.ts` — typed runtime config object passed through DI.
+
+## Key abstractions
+
+- **`Strategy`** (`src/strategies/types.ts`): `{ policies, run(task, toolkit, signal) }`. `policies.uses` declares which tools the strategy may call (the daemon defers the task until all are rate-limit-clear). `run` is async, must call `signal.throwIfAborted()` between awaits.
+- **`Toolkit`** (`src/strategies/types.ts`): per-task facade exposing `github` / `workspace` / `ai` / `log`. The contract: call `tk.workspace.prepare*` and `tk.github.fetchContext` **before** `tk.ai.run`. Workspaces are held with `await using` and the toolkit remembers the active one to route AI invocations.
+- **`PromptFragment`** (`src/strategies/types.ts`): tagged union for prompt assembly. Kinds: `file` (loads from `definitions/prompts/<subdir>/<name>.md` via the prompt cache), `literal`, `context` (renders a piece of the GitHub source context), `user` (additional task instructions).
+- **`AiRunOptions.allowedTools` / `disallowedTools`**: portable permission vocabulary (`read`, `grep`, `glob`, `edit`, `write`, `shell:<token-prefix>`). Each `ToolRunner` translates to the underlying CLI's syntax. Canonical preset sets in `src/strategies/_shared/tool-presets.ts` (`OBSERVE_ALLOWED`, `COLLECT_ONLY_ALLOWED`, `MUTATE_ALLOWED`, `MUTATE_DISALLOWED`, `REPLY_DISALLOWED`).
+- **`ToolRunner`** (`src/domain/ports/tool-runner.ts`): one per AI CLI. Receives translated permission set, prompt text, workspace path; returns `{ kind: "succeeded" | "failed" | "rate_limited" }`. Rate-limit detection is per-runner pattern matching against stderr/stdout.
+
+## Flow
+
+```
+webhook → WebhookHandler → EventDispatcher → EnqueueService
+       → FileQueueStore (var/queue/queued/<id>.json)
+       → RunnerDaemon (poll loop)
+       → Strategy.run(task, Toolkit, signal)
+       →   tk.workspace.prepare* (clone target repo)
+       →   tk.github.fetchContext (issue/PR body, comments, diff, linked refs)
+       →   tk.ai.run (PromptRenderer.render → ToolRunner.run)
+       →   tk.github.post* (comment / PR body)
+       → status transition (running → succeeded / failed / superseded)
+```
+
+## Adding things
+
+- **New instruction**: add `src/strategies/<id>.ts` implementing `Strategy`, register in `src/strategies/index.ts`, wire webhook → instruction in `src/services/event-dispatcher.ts`.
+- **New AI tool**: add `<NAME>_COMMAND` env var, write `<Name>ToolRunner` under `src/infra/tool/` implementing `ToolRunner`, register in `src/index.ts` `toolEntries`.
+- **New prompt fragment**: drop `definitions/prompts/<subdir>/<name>.md`. Reference via `{ kind: "file", path: "<subdir>/<name>" }` from a strategy.
+
+## Hard rules
+
+- Strategies never import from `src/infra/**`. If you need a new capability, add a method to the toolkit (or a new port) — don't reach around it.
+- The daemon owns task status transitions. Strategies return `{ status: "succeeded" | "failed" | "rate_limited" }` only; they don't write queue files directly.
+- `main` is protected server-side. Code shouldn't try to push to `main`; `buildBranchName(task)` always produces `ai/<kind>-<number>`.

--- a/.omgr/architecture.md
+++ b/.omgr/architecture.md
@@ -1,48 +1,37 @@
 # Architecture
 
-TypeScript ESM project. Layered: **domain → services → infra → daemon → cli/index**. Higher layers depend on lower; reverse imports are layering breaks.
+TypeScript ESM. Layers: **domain → services → infra → daemon → cli**. Reverse imports break layering.
 
-## Layers
+## Module roles
 
-- `src/domain/` — pure types and rules. No IO. Files: `task.ts`, `github.ts`, `tool.ts`, `queue-task.ts`, `task-status.ts`, `rules/*.ts`, `ports/*.ts`.
-- `src/domain/ports/` — interfaces that infra implements. The seam between business logic and IO. `github-client.ts`, `workspace-manager.ts`, `tool-runner.ts`, `queue-store.ts`, `log-store.ts`, `process-runner.ts`.
-- `src/services/` — orchestration. Composes ports into use cases. `enqueue-service.ts`, `event-dispatcher.ts`, `scheduler-service.ts`, `webhook-handler.ts`, `toolkit.ts`, `tool-registry.ts`, `sticky-comment.ts`.
-- `src/infra/` — adapters that implement the ports. Subdirs by area: `github/`, `queue/`, `logs/`, `tool/`, `workspaces/`, `prompts/`, `webhook/`, `platform/`.
-- `src/strategies/` — one file per instruction id. Each implements `Strategy` (`src/strategies/types.ts`). Use **only** the toolkit; never import from `src/infra/**`. Registered in the Map at `src/strategies/index.ts` (key MUST equal the `instructionId`).
-- `src/daemon/runner-daemon.ts` — owns the queue loop: pulls queued tasks, runs the strategy, transitions status, applies rate-limit pause.
-- `src/index.ts` — composition root. Wires env → infra → services → daemon. The only file that imports from every layer.
-- `src/runtime.ts` — typed runtime config object passed through DI.
+- `domain/` — pure types/rules. No IO.
+- `domain/ports/` — interfaces. The IO seam.
+- `services/` — orchestration over ports.
+- `infra/<area>/` — port adapters: `github/`, `queue/`, `logs/`, `tool/`, `workspaces/`, `prompts/`, `webhook/`, `platform/`.
+- `strategies/<id>.ts` — one per instructionId. Use **only** Toolkit.
+- `daemon/runner-daemon.ts` — queue loop. Owns status transitions.
+- `index.ts` — composition root.
 
-## Key abstractions
+## Load-bearing types (`src/strategies/types.ts`)
 
-- **`Strategy`** (`src/strategies/types.ts`): `{ policies, run(task, toolkit, signal) }`. `policies.uses` declares which tools the strategy may call (the daemon defers the task until all are rate-limit-clear). `run` is async, must call `signal.throwIfAborted()` between awaits.
-- **`Toolkit`** (`src/strategies/types.ts`): per-task facade exposing `github` / `workspace` / `ai` / `log`. The contract: call `tk.workspace.prepare*` and `tk.github.fetchContext` **before** `tk.ai.run`. Workspaces are held with `await using` and the toolkit remembers the active one to route AI invocations.
-- **`PromptFragment`** (`src/strategies/types.ts`): tagged union for prompt assembly. Kinds: `file` (loads from `definitions/prompts/<subdir>/<name>.md` via the prompt cache), `literal`, `context` (renders a piece of the GitHub source context), `user` (additional task instructions).
-- **`AiRunOptions.allowedTools` / `disallowedTools`**: portable permission vocabulary (`read`, `grep`, `glob`, `edit`, `write`, `shell:<token-prefix>`). Each `ToolRunner` translates to the underlying CLI's syntax. Canonical preset sets in `src/strategies/_shared/tool-presets.ts` (`OBSERVE_ALLOWED`, `COLLECT_ONLY_ALLOWED`, `MUTATE_ALLOWED`, `MUTATE_DISALLOWED`, `REPLY_DISALLOWED`).
-- **`ToolRunner`** (`src/domain/ports/tool-runner.ts`): one per AI CLI. Receives translated permission set, prompt text, workspace path; returns `{ kind: "succeeded" | "failed" | "rate_limited" }`. Rate-limit detection is per-runner pattern matching against stderr/stdout.
+- **`Strategy.policies.uses`** — set of tools. Daemon defers task until ALL clear of rate-limit.
+- **`Strategy.run`** — must call `signal.throwIfAborted()` between awaits.
+- **Toolkit contract** — `workspace.prepare*` AND `github.fetchContext` MUST run before `ai.run`. Workspaces held with `await using`.
+- **`PromptFragment`** — kinds: `file`, `literal`, `context`, `user`, `omgr-doc`.
+- **`AiRunOptions.allowed/disallowedTools`** — portable vocab: `read`, `grep`, `glob`, `edit`, `write`, `shell:<token-prefix>`. Each `ToolRunner` translates. Presets: `src/strategies/_shared/tool-presets.ts` (`OBSERVE_ALLOWED`, `COLLECT_ONLY_ALLOWED`, `MUTATE_ALLOWED`, `MUTATE_DISALLOWED`, `REPLY_DISALLOWED`).
 
 ## Flow
 
-```
-webhook → WebhookHandler → EventDispatcher → EnqueueService
-       → FileQueueStore (var/queue/queued/<id>.json)
-       → RunnerDaemon (poll loop)
-       → Strategy.run(task, Toolkit, signal)
-       →   tk.workspace.prepare* (clone target repo)
-       →   tk.github.fetchContext (issue/PR body, comments, diff, linked refs)
-       →   tk.ai.run (PromptRenderer.render → ToolRunner.run)
-       →   tk.github.post* (comment / PR body)
-       → status transition (running → succeeded / failed / superseded)
-```
+webhook → WebhookHandler → EventDispatcher → EnqueueService → FileQueueStore → RunnerDaemon → `Strategy.run` → (workspace.prepare*, github.fetchContext, ai.run, github.post*) → status transition
 
-## Adding things
+## Adding
 
-- **New instruction**: add `src/strategies/<id>.ts` implementing `Strategy`, register in `src/strategies/index.ts`, wire webhook → instruction in `src/services/event-dispatcher.ts`.
-- **New AI tool**: add `<NAME>_COMMAND` env var, write `<Name>ToolRunner` under `src/infra/tool/` implementing `ToolRunner`, register in `src/index.ts` `toolEntries`.
-- **New prompt fragment**: drop `definitions/prompts/<subdir>/<name>.md`. Reference via `{ kind: "file", path: "<subdir>/<name>" }` from a strategy.
+- **Instruction**: `src/strategies/<id>.ts` + register in `src/strategies/index.ts` + wire event in `src/services/event-dispatcher.ts`.
+- **AI tool**: `<NAME>_COMMAND` env + `<Name>ToolRunner` in `src/infra/tool/` + register in `src/index.ts` `toolEntries`.
+- **Prompt fragment**: drop md at `definitions/prompts/<sub>/<name>.md`, reference via `{ kind: "file", path: "<sub>/<name>" }`.
 
 ## Hard rules
 
-- Strategies never import from `src/infra/**`. If you need a new capability, add a method to the toolkit (or a new port) — don't reach around it.
-- The daemon owns task status transitions. Strategies return `{ status: "succeeded" | "failed" | "rate_limited" }` only; they don't write queue files directly.
-- `main` is protected server-side. Code shouldn't try to push to `main`; `buildBranchName(task)` always produces `ai/<kind>-<number>`.
+- Strategies never import `src/infra/**`. Need a capability? Add to toolkit (or a new port).
+- Daemon owns status. Strategies return `{ status }` only — never write queue files directly.
+- Never push `main` (server-side protected). `buildBranchName(task)` produces `ai/<kind>-<number>`.

--- a/.omgr/deployment.md
+++ b/.omgr/deployment.md
@@ -1,0 +1,49 @@
+# Deployment
+
+Single Oracle VM. Two systemd services:
+
+- `oh-my-github-runner.service` — Node.js daemon (queue + webhook server, bound to `127.0.0.1:${WEBHOOK_PORT}`).
+- `cloudflared.service` — Cloudflare tunnel exposing `https://<runner-host>` to the local port.
+
+Both run as the `ubuntu` user. Code lives under `/home/ubuntu/`; secrets under `/etc/oh-my-github-runner/`.
+
+The full operator handbook (env vars, GitHub App setup, tunnel verification, deploy workflow, forking) is in [`docs/deployment.md`](../docs/deployment.md). This file is the agent-facing crib sheet — for human operator steps, prefer `docs/deployment.md` and link to it.
+
+## Two clones on the VM
+
+- `/home/ubuntu/runner-deploy/` — what systemd runs. Owns `dist/` and `var/`. The deploy script `git reset --hard origin/main` on every push, so any local edit here is lost.
+- `/home/ubuntu/oh-my-github-runner/` — optional dev clone for editing on the VM. Not touched by the deploy script.
+
+If you (the agent) are running inside the deploy clone, treat its working tree as throwaway between deploys; if running inside the dev clone, edits persist until committed.
+
+## State directories (`var/`)
+
+- `var/queue/<status>/<taskId>.json` — task records. Status encoded by directory: `queued/`, `running/`, `succeeded/`, `failed/`, `superseded/`. Transitions are atomic cross-directory `rename(2)`; a task is in exactly one directory at any moment.
+- `var/queue/state.json` — per-tool rate-limit `pausedUntil`. Deleting this file is the manual "resume now" override.
+- `var/repos/<owner>/<name>/mirror.git` — bare mirror per repo, cached across tasks.
+- `var/workspaces/<task-id>/` — per-task working tree. Removed on task completion; orphans on the deploy clone come from crashed runs.
+- `var/logs/<task-id>.log` — per-task log line history.
+
+## Continuous deployment
+
+`push` to `main` triggers `.github/workflows/deploy.yml`: an ephemeral Tailscale node SSHes into the VM (`tag:server`) using **Tailscale SSH** (no SSH keys in GitHub) and runs `ops/scripts/deploy.sh`. The script waits for `var/queue/running/` to drain (poll every 5s, no internal timeout — bounded by the workflow's 15-minute `timeout-minutes`), then resets, reinstalls deps, recompiles, restarts the service. Build failures abort the deploy without touching the running daemon.
+
+In-flight tasks finish on the old code (already loaded into the running process); `queued` tasks survive the restart and resume on the new code.
+
+## Observability
+
+- Daemon logs: `journalctl -u oh-my-github-runner.service -f`
+- Tunnel logs: `journalctl -u cloudflared.service -f`
+- Current commit on the VM: `git -C /home/ubuntu/runner-deploy log -1 --oneline`
+- Per-task log: `var/logs/<task-id>.log`
+- Per-task transcript (claude tool): `~/.claude/projects/<encoded-cwd>/` (cleaned in the same `finally` that removes the workspace)
+
+## Recovery
+
+`recoverRunningTasks` runs at daemon boot and marks any `running/` files as failed (a daemon crash is the only way for them to be there once `deploy.sh` waits for drain). The failure callback posts a "Task <id> failed before completion: <summary>" comment on the originating issue/PR. Orphaned workspace directories under `var/workspaces/` are not auto-cleaned in v1.
+
+## Hard rules for changes
+
+- Never modify CI workflows (`.github/workflows/**`), systemd units, or `ops/scripts/deploy.sh` unless the task explicitly asks for it. The GitHub App for omgr lacks the `workflows` permission, so PRs that touch `.github/workflows/**` will fail to push from inside an agent run anyway.
+- Never push directly to `main` — it's branch-protected and the runner's branch naming (`buildBranchName`) always produces `ai/<kind>-<number>`.
+- Never echo secrets (token-shaped strings, `.pem` content, env values) into output, code, or commit messages.

--- a/.omgr/deployment.md
+++ b/.omgr/deployment.md
@@ -1,49 +1,40 @@
 # Deployment
 
-Single Oracle VM. Two systemd services:
+Single Oracle VM. Two services: `oh-my-github-runner.service` (Node daemon) + `cloudflared.service` (tunnel). Both as `ubuntu`. Secrets under `/etc/oh-my-github-runner/`.
 
-- `oh-my-github-runner.service` — Node.js daemon (queue + webhook server, bound to `127.0.0.1:${WEBHOOK_PORT}`).
-- `cloudflared.service` — Cloudflare tunnel exposing `https://<runner-host>` to the local port.
+Full operator handbook: [`docs/deployment.md`](../docs/deployment.md). This file is the agent-facing crib.
 
-Both run as the `ubuntu` user. Code lives under `/home/ubuntu/`; secrets under `/etc/oh-my-github-runner/`.
+## Two clones
 
-The full operator handbook (env vars, GitHub App setup, tunnel verification, deploy workflow, forking) is in [`docs/deployment.md`](../docs/deployment.md). This file is the agent-facing crib sheet — for human operator steps, prefer `docs/deployment.md` and link to it.
+- `/home/ubuntu/runner-deploy/` — what systemd runs. Owns `dist/` and `var/`. `git reset --hard origin/main` on every deploy — local edits lost.
+- `/home/ubuntu/oh-my-github-runner/` — optional dev clone. Not touched by deploy.
 
-## Two clones on the VM
+## State (`var/`)
 
-- `/home/ubuntu/runner-deploy/` — what systemd runs. Owns `dist/` and `var/`. The deploy script `git reset --hard origin/main` on every push, so any local edit here is lost.
-- `/home/ubuntu/oh-my-github-runner/` — optional dev clone for editing on the VM. Not touched by the deploy script.
+- `queue/<status>/<taskId>.json` — task records. Status = directory (`queued/`, `running/`, `succeeded/`, `failed/`, `superseded/`). Transitions = atomic cross-dir `rename(2)`.
+- `queue/state.json` — per-tool rate-limit `pausedUntil`. Delete to resume now.
+- `repos/<owner>/<name>/mirror.git` — cached bare mirrors.
+- `workspaces/<task-id>/` — per-task tree. Removed on completion; orphans = crashed runs.
+- `logs/<task-id>.log` — per-task log.
 
-If you (the agent) are running inside the deploy clone, treat its working tree as throwaway between deploys; if running inside the dev clone, edits persist until committed.
+## CD
 
-## State directories (`var/`)
+`push main` → `.github/workflows/deploy.yml` → ephemeral Tailscale node SSHes VM (`tag:server`, Tailscale SSH — no SSH keys in GitHub) → `ops/scripts/deploy.sh`: drain `var/queue/running/` (poll 5s, no internal timeout — bound by 15-min workflow), reset, reinstall, recompile, restart. Build failures abort without touching the running daemon. In-flight tasks finish on old code; queued tasks resume on new.
 
-- `var/queue/<status>/<taskId>.json` — task records. Status encoded by directory: `queued/`, `running/`, `succeeded/`, `failed/`, `superseded/`. Transitions are atomic cross-directory `rename(2)`; a task is in exactly one directory at any moment.
-- `var/queue/state.json` — per-tool rate-limit `pausedUntil`. Deleting this file is the manual "resume now" override.
-- `var/repos/<owner>/<name>/mirror.git` — bare mirror per repo, cached across tasks.
-- `var/workspaces/<task-id>/` — per-task working tree. Removed on task completion; orphans on the deploy clone come from crashed runs.
-- `var/logs/<task-id>.log` — per-task log line history.
+## Logs
 
-## Continuous deployment
-
-`push` to `main` triggers `.github/workflows/deploy.yml`: an ephemeral Tailscale node SSHes into the VM (`tag:server`) using **Tailscale SSH** (no SSH keys in GitHub) and runs `ops/scripts/deploy.sh`. The script waits for `var/queue/running/` to drain (poll every 5s, no internal timeout — bounded by the workflow's 15-minute `timeout-minutes`), then resets, reinstalls deps, recompiles, restarts the service. Build failures abort the deploy without touching the running daemon.
-
-In-flight tasks finish on the old code (already loaded into the running process); `queued` tasks survive the restart and resume on the new code.
-
-## Observability
-
-- Daemon logs: `journalctl -u oh-my-github-runner.service -f`
-- Tunnel logs: `journalctl -u cloudflared.service -f`
-- Current commit on the VM: `git -C /home/ubuntu/runner-deploy log -1 --oneline`
-- Per-task log: `var/logs/<task-id>.log`
-- Per-task transcript (claude tool): `~/.claude/projects/<encoded-cwd>/` (cleaned in the same `finally` that removes the workspace)
+- Daemon: `journalctl -u oh-my-github-runner.service -f`
+- Tunnel: `journalctl -u cloudflared.service -f`
+- Per-task: `var/logs/<task-id>.log`
+- Claude transcript: `~/.claude/projects/<encoded-cwd>/` (cleaned with workspace)
+- VM HEAD: `git -C /home/ubuntu/runner-deploy log -1 --oneline`
 
 ## Recovery
 
-`recoverRunningTasks` runs at daemon boot and marks any `running/` files as failed (a daemon crash is the only way for them to be there once `deploy.sh` waits for drain). The failure callback posts a "Task <id> failed before completion: <summary>" comment on the originating issue/PR. Orphaned workspace directories under `var/workspaces/` are not auto-cleaned in v1.
+`recoverRunningTasks` runs at boot, marks `running/` files as failed (only path: daemon crash, since `deploy.sh` waits for drain). Failure callback posts "Task <id> failed before completion: <summary>" to issue/PR. Orphan workspaces under `var/workspaces/` not auto-cleaned in v1.
 
-## Hard rules for changes
+## Hard rules
 
-- Never modify CI workflows (`.github/workflows/**`), systemd units, or `ops/scripts/deploy.sh` unless the task explicitly asks for it. The GitHub App for omgr lacks the `workflows` permission, so PRs that touch `.github/workflows/**` will fail to push from inside an agent run anyway.
-- Never push directly to `main` — it's branch-protected and the runner's branch naming (`buildBranchName`) always produces `ai/<kind>-<number>`.
-- Never echo secrets (token-shaped strings, `.pem` content, env values) into output, code, or commit messages.
+- Don't touch `.github/workflows/**`, systemd units, or `ops/scripts/deploy.sh` unless the task explicitly asks. The omgr GitHub App lacks `workflows` permission — pushes touching `.github/workflows/**` will fail anyway.
+- Never push `main` directly. `buildBranchName` produces `ai/<kind>-<number>`.
+- Never echo secrets (token-shaped strings, `.pem` content, env values).

--- a/.omgr/overview.md
+++ b/.omgr/overview.md
@@ -1,0 +1,19 @@
+# Overview
+
+`oh-my-github-runner` (omgr) is a single-owner, single-VM GitHub automation runner. A GitHub App webhook fires on issues / issue comments / PR review comments, the runner enqueues a task, and a daemon executes the task by clones-and-runs against the target repo using one of several AI tool CLIs (Claude / Codex / Gemini).
+
+## Key terms
+
+- **Task** — a single unit of work to run for a specific issue or PR. Persisted as a JSON file under `var/queue/<status>/`.
+- **Strategy** — the per-instruction implementation. Decides what context to fetch, which persona/mode/tool to invoke, and what to publish back to GitHub. Lives under `src/strategies/`.
+- **Instruction** — the routing key carried by a task (`issue-initial-review`, `issue-implement`, `pr-implement`, `pr-review-comment`, `issue-comment-reply`). One strategy per instruction.
+- **Toolkit** — the per-task facade that strategies use. Wraps GitHub access, workspace lifecycle, AI invocation, and logging. Strategies must use only the toolkit; importing from `src/infra/**` is a layering break.
+- **Persona / Mode** — markdown fragments under `definitions/prompts/{personas,modes}` that shape the AI invocation. Personas define the lens (architect, test, ops, …); modes define what the AI is allowed to do (collect-only / observe / mutate).
+- **Tool runner** — adapter for one AI CLI (`claude`, `codex`, `gemini`). Owns argv, permission translation, and rate-limit pattern matching. Lives under `src/infra/tool/`.
+- **Workspace** — a per-task throwaway clone under `var/workspaces/<task-id>/`. Strategies hold it via `await using` so disposal cleans branch state and tool artifacts.
+
+## Operating model
+
+- One repo owner, one VM, one daemon process. Throughput is intentionally small — the runner waits for ALL tools listed in a strategy's `policies.uses` to be clear of rate-limit before starting the task.
+- The runner never pushes to `main`. Mutating strategies always work on `ai/<kind>-<number>` branches and open PRs. `main` is server-side protected.
+- The agent is the source of judgment — it decides whether to push, open a PR, comment, etc. The runner is a thin shim around tool invocation and lifecycle.

--- a/.omgr/overview.md
+++ b/.omgr/overview.md
@@ -1,19 +1,20 @@
 # Overview
 
-`oh-my-github-runner` (omgr) is a single-owner, single-VM GitHub automation runner. A GitHub App webhook fires on issues / issue comments / PR review comments, the runner enqueues a task, and a daemon executes the task by clones-and-runs against the target repo using one of several AI tool CLIs (Claude / Codex / Gemini).
+Single-owner, single-VM GitHub automation runner. Webhook → enqueue → daemon → clone target repo → run AI tool CLI (claude/codex/gemini) → post back.
 
-## Key terms
+## Terms
 
-- **Task** — a single unit of work to run for a specific issue or PR. Persisted as a JSON file under `var/queue/<status>/`.
-- **Strategy** — the per-instruction implementation. Decides what context to fetch, which persona/mode/tool to invoke, and what to publish back to GitHub. Lives under `src/strategies/`.
-- **Instruction** — the routing key carried by a task (`issue-initial-review`, `issue-implement`, `pr-implement`, `pr-review-comment`, `issue-comment-reply`). One strategy per instruction.
-- **Toolkit** — the per-task facade that strategies use. Wraps GitHub access, workspace lifecycle, AI invocation, and logging. Strategies must use only the toolkit; importing from `src/infra/**` is a layering break.
-- **Persona / Mode** — markdown fragments under `definitions/prompts/{personas,modes}` that shape the AI invocation. Personas define the lens (architect, test, ops, …); modes define what the AI is allowed to do (collect-only / observe / mutate).
-- **Tool runner** — adapter for one AI CLI (`claude`, `codex`, `gemini`). Owns argv, permission translation, and rate-limit pattern matching. Lives under `src/infra/tool/`.
-- **Workspace** — a per-task throwaway clone under `var/workspaces/<task-id>/`. Strategies hold it via `await using` so disposal cleans branch state and tool artifacts.
+- **Task** — unit of work. JSON under `var/queue/<status>/`.
+- **Strategy** — per-instruction logic. `src/strategies/<id>.ts`. One per instructionId.
+- **Instruction** — routing key: `issue-initial-review`, `issue-implement`, `pr-implement`, `pr-review-comment`, `issue-comment-reply`.
+- **Toolkit** — per-task facade (`github` / `workspace` / `ai` / `log`). Strategies use only this — never import `src/infra/**`.
+- **Persona / Mode** — md under `definitions/prompts/{personas,modes}`. Persona = lens; Mode = permission preset.
+- **ToolRunner** — adapter for one CLI. `src/infra/tool/`. Owns argv, permission translation, rate-limit detection.
+- **Workspace** — throwaway clone at `var/workspaces/<task-id>/`. Held with `await using`.
 
-## Operating model
+## Model
 
-- One repo owner, one VM, one daemon process. Throughput is intentionally small — the runner waits for ALL tools listed in a strategy's `policies.uses` to be clear of rate-limit before starting the task.
-- The runner never pushes to `main`. Mutating strategies always work on `ai/<kind>-<number>` branches and open PRs. `main` is server-side protected.
-- The agent is the source of judgment — it decides whether to push, open a PR, comment, etc. The runner is a thin shim around tool invocation and lifecycle.
+- One owner, one VM, one daemon. Throughput intentionally small.
+- Daemon defers a task until ALL tools in `policies.uses` are rate-limit-clear.
+- Never pushes `main` (server-side protected). Mutating strategies → `ai/<kind>-<number>` branches → PRs.
+- Agent owns judgment (push/PR/comment). Runner is a thin shim.

--- a/.omgr/testing.md
+++ b/.omgr/testing.md
@@ -1,0 +1,30 @@
+# Testing
+
+## Framework
+
+- `node:test` with `assert/strict`. No external test runner, no mocking library.
+- TypeScript is compiled to JS first (`tsconfig.test.json` → `.test-dist/`); `tools/run-tests.mjs` then imports every `*.test.js` under `.test-dist/tests/` and runs them.
+- Run everything: `npm test`. Run a subset: `npm test -- .test-dist/tests/unit/<file>.test.js`.
+
+## Layout
+
+- `tests/unit/*.test.ts` — pure unit tests. Mock at the **port** boundary (`src/domain/ports/*`), not internal helpers. Most files mirror a single source file (e.g. `toolkit.test.ts` covers `src/services/toolkit.ts`).
+- `tests/integration/*.test.ts` — multi-layer tests that don't touch real GitHub (HTTP contract → file queue → dispatcher → enqueue, etc.). Use these only when a unit test can't capture the cross-component invariant. The README inside lists the manual end-to-end smoke procedure (real webhook against a real repo).
+
+## Conventions
+
+- One reason to fail per test. A failing assertion should point at one root cause.
+- For new behaviors: minimum one happy path + one failure path. For bug fixes: a regression test that fails before the fix, passes after.
+- Use `mkdtemp(join(tmpdir(), "<prefix>-"))` + `await rm(root, { recursive: true, force: true })` in a `try/finally` for any test that touches the filesystem. `tests/unit/file-log-store.test.ts` is the reference pattern.
+- Don't mock internal helpers or assert on private shapes — those tests rot the next time the implementation moves. Stick to the port seam.
+- For strategies, tests typically build a stub `Toolkit` and assert on the fragments passed into `tk.ai.run` (which persona file is used, which `omgr-doc` path, which `allowedTools` preset). See `tests/unit/issue-initial-review-strategy.test.ts` for the multi-persona pattern.
+
+## Running
+
+```sh
+npm run build       # tsc --noEmit (type check only)
+npm test            # compile tests then execute
+npm run compile     # full runtime build to dist/ (needed for `npm run daemon`)
+```
+
+`npm test` reports TAP. CI runs `npm test` on the VM at deploy time only — there is no PR-level CI in v1, so test failures should be caught locally before push.

--- a/.omgr/testing.md
+++ b/.omgr/testing.md
@@ -1,30 +1,30 @@
 # Testing
 
-## Framework
+## Stack
 
-- `node:test` with `assert/strict`. No external test runner, no mocking library.
-- TypeScript is compiled to JS first (`tsconfig.test.json` → `.test-dist/`); `tools/run-tests.mjs` then imports every `*.test.js` under `.test-dist/tests/` and runs them.
-- Run everything: `npm test`. Run a subset: `npm test -- .test-dist/tests/unit/<file>.test.js`.
+- `node:test` + `assert/strict`. No external runners or mocking libs.
+- Compile then run: `tsconfig.test.json` → `.test-dist/`, `tools/run-tests.mjs` imports every `.test.js`.
+
+## Run
+
+- All: `npm test`
+- Subset: `npm test -- .test-dist/tests/unit/<file>.test.js`
+- Type check only: `npm run build`
+- Runtime build (for `npm run daemon`): `npm run compile`
 
 ## Layout
 
-- `tests/unit/*.test.ts` — pure unit tests. Mock at the **port** boundary (`src/domain/ports/*`), not internal helpers. Most files mirror a single source file (e.g. `toolkit.test.ts` covers `src/services/toolkit.ts`).
-- `tests/integration/*.test.ts` — multi-layer tests that don't touch real GitHub (HTTP contract → file queue → dispatcher → enqueue, etc.). Use these only when a unit test can't capture the cross-component invariant. The README inside lists the manual end-to-end smoke procedure (real webhook against a real repo).
+- `tests/unit/*.test.ts` — mock at port boundary (`src/domain/ports/*`). One file ≈ one source file.
+- `tests/integration/*.test.ts` — multi-layer, no real GitHub. Use only when a unit test can't capture the invariant.
 
 ## Conventions
 
-- One reason to fail per test. A failing assertion should point at one root cause.
-- For new behaviors: minimum one happy path + one failure path. For bug fixes: a regression test that fails before the fix, passes after.
-- Use `mkdtemp(join(tmpdir(), "<prefix>-"))` + `await rm(root, { recursive: true, force: true })` in a `try/finally` for any test that touches the filesystem. `tests/unit/file-log-store.test.ts` is the reference pattern.
-- Don't mock internal helpers or assert on private shapes — those tests rot the next time the implementation moves. Stick to the port seam.
-- For strategies, tests typically build a stub `Toolkit` and assert on the fragments passed into `tk.ai.run` (which persona file is used, which `omgr-doc` path, which `allowedTools` preset). See `tests/unit/issue-initial-review-strategy.test.ts` for the multi-persona pattern.
+- One reason to fail per test.
+- New behavior: ≥1 happy path + ≥1 failure path. Bug fix: regression test that fails before / passes after.
+- Filesystem tests: `mkdtemp` + `try/finally` + `rm(root, { recursive: true, force: true })`. Reference: `tests/unit/file-log-store.test.ts`.
+- Don't mock internal helpers or assert on private shapes — they rot. Stick to the port seam.
+- Strategy tests: stub `Toolkit`, assert on `tk.ai.run` fragments (persona file, omgr-doc path, allowedTools preset). Reference: `tests/unit/issue-initial-review-strategy.test.ts`.
 
-## Running
+## CI
 
-```sh
-npm run build       # tsc --noEmit (type check only)
-npm test            # compile tests then execute
-npm run compile     # full runtime build to dist/ (needed for `npm run daemon`)
-```
-
-`npm test` reports TAP. CI runs `npm test` on the VM at deploy time only — there is no PR-level CI in v1, so test failures should be caught locally before push.
+No PR-level CI in v1. `npm test` runs on the VM at deploy time only — catch failures locally before push.


### PR DESCRIPTION
Adds the four standard `.omgr/` files for the omgr repo itself, so that once #98 merges, omgr-on-omgr task runs auto-inject these into the relevant personas.

## Files

- `.omgr/overview.md` — what omgr is, key terms (task / strategy / instruction / toolkit / persona / mode / tool runner / workspace), operating model.
- `.omgr/architecture.md` — domain → services → infra → daemon → cli layering, key abstractions (`Strategy` / `Toolkit` / `PromptFragment` / `AiRunOptions` / `ToolRunner`), end-to-end flow, hard rules.
- `.omgr/testing.md` — `node:test`, `tsc -p tsconfig.test.json` + `tools/run-tests.mjs`, unit vs integration layout, conventions, run commands.
- `.omgr/deployment.md` — agent-facing crib sheet of `docs/deployment.md`: two-clone layout, `var/` state, CD via Tailscale SSH, observability, hard rules. Links to `docs/deployment.md` for full operator handbook.

## Notes

- Pure markdown — no code dependency. Can merge before or after #98; only takes effect once #98 is in.
- Written in English to match the existing convention for `definitions/prompts/**` and `definitions/instructions/**` (only agent output is Korean).
- Doesn't duplicate `docs/deployment.md`. The deployment file links to it for operator steps; the agent-facing crib sheet focuses on what an AI needs to know to do code work safely.

## Test plan
- [x] Files render as markdown correctly
- [ ] After #98 merges, trigger an issue-initial-review on this repo and verify each persona's prompt actually loads its mapped `.omgr/<file>.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)