### PR TITLE
feat(issue-comment-reply): move reply actions under runner control

### DIFF
--- a/definitions/prompts/modes/reply-structured.md
+++ b/definitions/prompts/modes/reply-structured.md
@@ -1,0 +1,11 @@
+# Structured Reply Mode Policy
+
+- Mode: structured-reply
+- Output exactly one JSON object that conforms to the provided schema.
+- Do not wrap the JSON in Markdown, code fences, or explanatory prose.
+- Do not call GitHub write APIs or `gh` write commands yourself. The runner
+  will execute any requested side effects after it parses your JSON.
+- `replyComment` is the main reply that will be posted to the source issue.
+  It must stand on its own even if every additional action fails.
+- `additionalActions` is for optional side effects only. Leave it as an empty
+  array when no extra action is needed.

--- a/definitions/prompts/personas/reply.md
+++ b/definitions/prompts/personas/reply.md
@@ -1,21 +1,31 @@
 # Reply Persona
 
-You answer issue/PR comments. The reader is the repository owner; they want to scan your reply, grasp the core in seconds, and decide what to do next. Optimize for *signal density*. This file only adds rules specific to reply contexts — voice and style live in `tone.md`, engineering posture in `engineering-stance.md`.
+You answer issue comments for the repository owner. Optimize for signal
+density: the reader should scan the reply, understand the answer quickly, and
+know what to do next. Voice and style live in `tone.md`; engineering posture
+lives in `engineering-stance.md`.
 
-## Priority order
+## `replyComment` content
 
-Include the items in this order. Drop any item that has nothing material to say — do not pad.
+Write the user-facing answer as `replyComment`. Keep it direct and useful.
 
-1. **Direct answer** — The conclusion to the question. One or two sentences.
-2. **Key reasoning** — Facts, constraints, and rationale the answer rests on. One or two lines per item.
-3. **Pitfalls** *(only when present)* — Decision branches, easily missed constraints, points needing further checking. Omit the section entirely if none.
-4. **Worth reviewing further** *(optional)* — Out-of-scope items worth knowing alongside. Do not pad.
+Preferred order inside the reply:
+
+1. Direct answer
+2. Key reasoning
+3. Pitfalls, only when present
+4. Worth reviewing further, only when present
 
 ## Code references
 
-- Prefer `path:line` references over pasted blocks. The user has the file open already.
-- Quote at most 1–3 lines, and only when the line itself is the point.
+- Prefer `path:line` references over pasted blocks.
+- Quote at most 1-2 lines, and only when the line itself is the point.
 
-## Action mode
+## Additional actions
 
-- If the user asked for an action (labeling, issue creation, related PR comments, etc.), perform it via `gh` and report what you did in one or two lines. The priority-order template above does not apply — keep the report flat.
+- Use `additionalActions` only for side effects the runner should execute after
+  parsing your output.
+- Allowed side effects in this workflow are opening a follow-up issue, closing
+  an issue, or posting a comment on another issue/PR.
+- Do not claim that a side effect already succeeded inside `replyComment`. The
+  runner will execute the side effects later and append the results.

--- a/src/domain/ports/github-client.ts
+++ b/src/domain/ports/github-client.ts
@@ -63,6 +63,12 @@ export interface GitHubClient {
     issueNumber: number,
     body: string,
   ): Promise<IssueCommentRef>;
+  createIssue(
+    repo: RepoRef,
+    title: string,
+    body: string,
+  ): Promise<{ number: number; url: string }>;
+  closeIssue(repo: RepoRef, issueNumber: number): Promise<void>;
   postPullRequestComment(
     repo: RepoRef,
     pullRequestNumber: number,

--- a/src/domain/tool.ts
+++ b/src/domain/tool.ts
@@ -9,6 +9,14 @@ export interface ToolRunInput {
   disallowedTools?: readonly string[];
   timeoutMs?: number;
   /**
+   * Optional JSON Schema describing the structured final output the
+   * model must produce. Runners that natively support structured output
+   * (codex) translate this into their CLI flags and return the
+   * schema-conformant JSON in `succeeded.stdout`. Runners that do not
+   * support it MUST throw rather than silently ignore the option.
+   */
+  outputSchema?: object;
+  /**
    * If aborted, the runner should kill its child process (SIGTERM with a
    * brief grace period before SIGKILL) and return a failed result.
    */

--- a/src/infra/github/github-app-client.ts
+++ b/src/infra/github/github-app-client.ts
@@ -282,6 +282,33 @@ export class GitHubAppClient implements GitHubClient {
     return this.postIssueComment(repo, pullRequestNumber, body);
   }
 
+  async createIssue(
+    repo: RepoRef,
+    title: string,
+    body: string,
+  ): Promise<{ number: number; url: string }> {
+    const response = await this.installationRequest<{
+      number: number;
+      html_url: string;
+    }>(
+      repo,
+      "POST",
+      `/repos/${repo.owner}/${repo.name}/issues`,
+      { title, body },
+    );
+
+    return { number: response.number, url: response.html_url };
+  }
+
+  async closeIssue(repo: RepoRef, issueNumber: number): Promise<void> {
+    await this.installationRequest(
+      repo,
+      "PATCH",
+      `/repos/${repo.owner}/${repo.name}/issues/${issueNumber}`,
+      { state: "closed" },
+    );
+  }
+
   async updateIssueComment(
     repo: RepoRef,
     commentId: number,

--- a/src/infra/tool/claude-tool-runner.ts
+++ b/src/infra/tool/claude-tool-runner.ts
@@ -43,6 +43,15 @@ export class ClaudeToolRunner implements ToolRunner {
   }
 
   async run(input: ToolRunInput): Promise<ToolRunResult> {
+    if (input.outputSchema !== undefined) {
+      // Native --json-schema support is feasible but not yet implemented.
+      // Strategies that need structured output should route through codex
+      // until this lands; throwing surfaces the misconfiguration instead
+      // of silently dropping the contract.
+      throw new Error(
+        "ClaudeToolRunner: outputSchema is not yet supported (route this call to codex)",
+      );
+    }
     const args = ["-p", ...this.buildPermissionArgs(input)];
 
     const raw = await this.options.processRunner.run({

--- a/src/infra/tool/claude-tool-runner.ts
+++ b/src/infra/tool/claude-tool-runner.ts
@@ -43,16 +43,16 @@ export class ClaudeToolRunner implements ToolRunner {
   }
 
   async run(input: ToolRunInput): Promise<ToolRunResult> {
-    if (input.outputSchema !== undefined) {
-      // Native --json-schema support is feasible but not yet implemented.
-      // Strategies that need structured output should route through codex
-      // until this lands; throwing surfaces the misconfiguration instead
-      // of silently dropping the contract.
-      throw new Error(
-        "ClaudeToolRunner: outputSchema is not yet supported (route this call to codex)",
-      );
-    }
     const args = ["-p", ...this.buildPermissionArgs(input)];
+    if (input.outputSchema !== undefined) {
+      // Claude Code's --json-schema validates the model's response against
+      // the supplied JSON Schema and emits the schema-conformant JSON as
+      // plain stdout. The schema travels inline as a single argv string;
+      // codex's equivalent uses a sidecar file because its CLI takes a
+      // path. Either runner ends up handing identical stdout shape to the
+      // caller, so strategies parse it from one place.
+      args.push("--json-schema", JSON.stringify(input.outputSchema));
+    }
 
     const raw = await this.options.processRunner.run({
       command: this.options.command,
@@ -63,6 +63,26 @@ export class ClaudeToolRunner implements ToolRunner {
       ...(input.signal !== undefined ? { signal: input.signal } : {}),
       env: buildBaseEnv(input),
     });
+
+    if (
+      input.outputSchema !== undefined &&
+      raw.exitCode === 0 &&
+      raw.stdout.trim().length === 0
+    ) {
+      // Empty stdout despite exit 0 means claude accepted the run but
+      // produced nothing matching the schema. Surface as failed so the
+      // receipt carries raw stdout/stderr rather than tripping downstream
+      // JSON parsing on an empty success.
+      return {
+        kind: "failed",
+        exitCode: 0,
+        stdout: raw.stdout,
+        stderr:
+          raw.stderr.length > 0
+            ? raw.stderr
+            : "claude produced empty stdout despite outputSchema",
+      };
+    }
 
     return classifyResult(raw, "claude", RATE_LIMIT_PATTERNS);
   }

--- a/src/infra/tool/codex-tool-runner.ts
+++ b/src/infra/tool/codex-tool-runner.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { ProcessRunner } from "../../domain/ports/process-runner.js";
 import type { ToolRunner } from "../../domain/ports/tool-runner.js";
@@ -8,6 +8,7 @@ import { buildBaseEnv, classifyResult } from "./_shared.js";
 export interface CodexFs {
   mkdir: (target: string, options: { recursive: true }) => Promise<unknown>;
   writeFile: (target: string, contents: string) => Promise<void>;
+  readFile: (target: string) => Promise<string>;
   rm: (
     target: string,
     options: { recursive: true; force: true },
@@ -38,12 +39,14 @@ export class CodexToolRunner implements ToolRunner {
     this.fs = options.fs ?? {
       mkdir: (target, opts) => mkdir(target, opts),
       writeFile,
+      readFile: (target) => readFile(target, "utf8"),
       rm,
     };
   }
 
   async run(input: ToolRunInput): Promise<ToolRunResult> {
     await this.writeRulesFile(input);
+    const lastMessagePath = await this.prepareOutputSchema(input);
 
     const args = [
       "exec",
@@ -53,9 +56,17 @@ export class CodexToolRunner implements ToolRunner {
       "--skip-git-repo-check",
       "-C",
       input.workspacePath,
-      "--",
-      input.prompt,
     ];
+    if (lastMessagePath !== null) {
+      const schemaPath = path.join(input.workspacePath, ".codex", "output.schema.json");
+      args.push(
+        "--output-schema",
+        schemaPath,
+        "-o",
+        lastMessagePath,
+      );
+    }
+    args.push("--", input.prompt);
 
     const raw = await this.options.processRunner.run({
       command: this.options.command,
@@ -66,7 +77,43 @@ export class CodexToolRunner implements ToolRunner {
       env: buildBaseEnv(input),
     });
 
+    // When outputSchema was used and the run succeeded, the schema-conformant
+    // JSON is written to `last-message.txt` rather than coming back through
+    // stdout. Read that file and surface its contents as the succeeded stdout
+    // so callers always parse the structured payload from a single place.
+    if (lastMessagePath !== null && raw.exitCode === 0) {
+      try {
+        const stdout = await this.fs.readFile(lastMessagePath);
+        return { kind: "succeeded", stdout };
+      } catch {
+        // File missing despite exit 0 — fall through to raw result so the
+        // caller sees the original stdout/stderr instead of a silent empty
+        // success.
+      }
+    }
+
     return classifyResult(raw, "codex", RATE_LIMIT_PATTERNS);
+  }
+
+  // Materialize the JSON Schema in the workspace's `.codex/` dir and
+  // return the absolute path the runner should pass to `codex exec -o`,
+  // or `null` when no schema was requested. Returning the path keeps the
+  // arg-construction site below free of fs concerns.
+  private async prepareOutputSchema(
+    input: ToolRunInput,
+  ): Promise<string | null> {
+    if (input.outputSchema === undefined) {
+      return null;
+    }
+    const codexDir = path.join(input.workspacePath, ".codex");
+    const schemaPath = path.join(codexDir, "output.schema.json");
+    const lastMessagePath = path.join(codexDir, "last-message.txt");
+    await this.fs.mkdir(codexDir, { recursive: true });
+    await this.fs.writeFile(
+      schemaPath,
+      JSON.stringify(input.outputSchema, null, 2) + "\n",
+    );
+    return lastMessagePath;
   }
 
   async cleanupArtifacts(workspacePath: string): Promise<void> {

--- a/src/infra/tool/codex-tool-runner.ts
+++ b/src/infra/tool/codex-tool-runner.ts
@@ -84,6 +84,21 @@ export class CodexToolRunner implements ToolRunner {
     if (lastMessagePath !== null && raw.exitCode === 0) {
       try {
         const stdout = await this.fs.readFile(lastMessagePath);
+        if (stdout.trim().length === 0) {
+          // File present but empty: codex accepted the run but emitted no
+          // schema-conformant message. Surface as failed with raw stdout/
+          // stderr so the receipt shows codex's actual logs instead of an
+          // opaque "Unexpected end of JSON input" downstream.
+          return {
+            kind: "failed",
+            exitCode: 0,
+            stdout: raw.stdout,
+            stderr:
+              raw.stderr.length > 0
+                ? raw.stderr
+                : "codex wrote an empty last-message.txt despite outputSchema",
+          };
+        }
         return { kind: "succeeded", stdout };
       } catch {
         // File missing despite exit 0 — fall through to raw result so the

--- a/src/services/toolkit.ts
+++ b/src/services/toolkit.ts
@@ -113,6 +113,16 @@ class ToolkitImpl implements Toolkit {
         body,
       );
     },
+
+    createIssue: (
+      repo: RepoRef,
+      title: string,
+      body: string,
+    ): Promise<{ number: number; url: string }> =>
+      this.options.githubClient.createIssue(repo, title, body),
+
+    closeIssue: (repo: RepoRef, issueNumber: number): Promise<void> =>
+      this.options.githubClient.closeIssue(repo, issueNumber),
   };
 
   readonly workspace = {
@@ -259,6 +269,9 @@ class ToolkitImpl implements Toolkit {
           ? { disallowedTools: opts.disallowedTools }
           : {}),
         ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+        ...(opts.outputSchema !== undefined
+          ? { outputSchema: opts.outputSchema }
+          : {}),
         ...(this.signal !== undefined ? { signal: this.signal } : {}),
       });
       if (result.kind === "succeeded") {

--- a/src/strategies/_shared/reply-actions.ts
+++ b/src/strategies/_shared/reply-actions.ts
@@ -1,0 +1,251 @@
+export interface CreateIssueAction {
+  kind: "create_issue";
+  title: string;
+  body: string;
+}
+
+export interface CloseIssueAction {
+  kind: "close_issue";
+  issueNumber: number;
+}
+
+export interface CommentAction {
+  kind: "comment";
+  targetKind: "issue" | "pull_request";
+  targetNumber: number;
+  body: string;
+}
+
+export type ReplyAdditionalAction =
+  | CreateIssueAction
+  | CloseIssueAction
+  | CommentAction;
+
+export interface IssueCommentReplyEnvelope {
+  replyComment: string;
+  additionalActions: ReplyAdditionalAction[];
+  reasoning: string;
+}
+
+export const ISSUE_COMMENT_REPLY_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["replyComment", "additionalActions", "reasoning"],
+  properties: {
+    replyComment: {
+      type: "string",
+      minLength: 1,
+    },
+    additionalActions: {
+      type: "array",
+      items: {
+        anyOf: [
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["kind", "title", "body"],
+            properties: {
+              kind: { type: "string", enum: ["create_issue"] },
+              title: { type: "string", minLength: 1 },
+              body: { type: "string", minLength: 1 },
+            },
+          },
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["kind", "issueNumber"],
+            properties: {
+              kind: { type: "string", enum: ["close_issue"] },
+              issueNumber: { type: "integer", minimum: 1 },
+            },
+          },
+          {
+            type: "object",
+            additionalProperties: false,
+            required: ["kind", "targetKind", "targetNumber", "body"],
+            properties: {
+              kind: { type: "string", enum: ["comment"] },
+              targetKind: {
+                type: "string",
+                enum: ["issue", "pull_request"],
+              },
+              targetNumber: { type: "integer", minimum: 1 },
+              body: { type: "string", minLength: 1 },
+            },
+          },
+        ],
+      },
+    },
+    reasoning: {
+      type: "string",
+      minLength: 1,
+    },
+  },
+} as const;
+
+export function parseIssueCommentReplyEnvelope(
+  stdout: string,
+  sourceIssueNumber: number,
+): IssueCommentReplyEnvelope {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(
+      `issue-comment-reply: failed to parse structured output as JSON: ${errorMessage(error)}`,
+    );
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error("issue-comment-reply: structured output must be a JSON object");
+  }
+
+  const replyComment = readNonEmptyString(parsed.replyComment, "replyComment");
+  const reasoning = readNonEmptyString(parsed.reasoning, "reasoning");
+  const rawActions = parsed.additionalActions;
+
+  if (!Array.isArray(rawActions)) {
+    throw new Error("issue-comment-reply: additionalActions must be an array");
+  }
+
+  const additionalActions = rawActions.map((entry, index) =>
+    parseAdditionalAction(entry, index, sourceIssueNumber),
+  );
+
+  return { replyComment, additionalActions, reasoning };
+}
+
+export function renderAdditionalActionReceipts(
+  receipts: readonly string[],
+): string {
+  if (receipts.length === 0) {
+    return "";
+  }
+  return ["Additional actions:", ...receipts.map((line) => `- ${line}`)].join(
+    "\n",
+  );
+}
+
+export function formatSucceededActionReceipt(
+  action: ReplyAdditionalAction,
+  result?: { number: number },
+): string {
+  switch (action.kind) {
+    case "create_issue":
+      return `Opened follow-up issue #${result?.number ?? "?"}: ${action.title}`;
+    case "close_issue":
+      return `Closed issue #${action.issueNumber}.`;
+    case "comment":
+      return `Commented on ${displayTarget(action.targetKind)} #${action.targetNumber}.`;
+  }
+}
+
+export function formatFailedActionReceipt(
+  action: ReplyAdditionalAction,
+  error: unknown,
+): string {
+  const detail = errorMessage(error);
+  switch (action.kind) {
+    case "create_issue":
+      return `Failed to open follow-up issue "${action.title}": ${detail}`;
+    case "close_issue":
+      return `Failed to close issue #${action.issueNumber}: ${detail}`;
+    case "comment":
+      return `Failed to comment on ${displayTarget(action.targetKind)} #${action.targetNumber}: ${detail}`;
+  }
+}
+
+function parseAdditionalAction(
+  value: unknown,
+  index: number,
+  sourceIssueNumber: number,
+): ReplyAdditionalAction {
+  if (!isRecord(value)) {
+    throw new Error(
+      `issue-comment-reply: additionalActions[${index}] must be an object`,
+    );
+  }
+
+  const kind = value.kind;
+  if (kind === "create_issue") {
+    return {
+      kind,
+      title: readNonEmptyString(value.title, `additionalActions[${index}].title`),
+      body: readNonEmptyString(value.body, `additionalActions[${index}].body`),
+    };
+  }
+
+  if (kind === "close_issue") {
+    return {
+      kind,
+      issueNumber: readPositiveInteger(
+        value.issueNumber,
+        `additionalActions[${index}].issueNumber`,
+      ),
+    };
+  }
+
+  if (kind === "comment") {
+    const targetKind = readTargetKind(
+      value.targetKind,
+      `additionalActions[${index}].targetKind`,
+    );
+    const targetNumber = readPositiveInteger(
+      value.targetNumber,
+      `additionalActions[${index}].targetNumber`,
+    );
+    if (targetKind === "issue" && targetNumber === sourceIssueNumber) {
+      throw new Error(
+        "issue-comment-reply: additionalActions.comment cannot target the source issue; use replyComment instead",
+      );
+    }
+    return {
+      kind,
+      targetKind,
+      targetNumber,
+      body: readNonEmptyString(value.body, `additionalActions[${index}].body`),
+    };
+  }
+
+  throw new Error(
+    `issue-comment-reply: unsupported additional action kind at index ${index}`,
+  );
+}
+
+function readNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`issue-comment-reply: ${field} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function readPositiveInteger(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new Error(`issue-comment-reply: ${field} must be a positive integer`);
+  }
+  return value;
+}
+
+function readTargetKind(
+  value: unknown,
+  field: string,
+): "issue" | "pull_request" {
+  if (value === "issue" || value === "pull_request") {
+    return value;
+  }
+  throw new Error(
+    `issue-comment-reply: ${field} must be either 'issue' or 'pull_request'`,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function displayTarget(targetKind: "issue" | "pull_request"): string {
+  return targetKind === "pull_request" ? "pull request" : "issue";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/strategies/_shared/tool-presets.ts
+++ b/src/strategies/_shared/tool-presets.ts
@@ -47,18 +47,3 @@ export const MUTATE_ALLOWED: readonly string[] = [
 export const MUTATE_DISALLOWED: readonly string[] = [
   "shell:gh pr merge",
 ];
-
-// Narrow carve-outs from `OBSERVE_ALLOWED` for issue-comment-reply: the
-// strategy's contract lets the model use the full `gh` surface to fulfill
-// natural-language action delegations (label, open follow-up issue, etc.),
-// but anything that can mutate the codebase or repo metadata stays blocked.
-export const REPLY_DISALLOWED: readonly string[] = [
-  "shell:gh pr merge",
-  "shell:gh repo edit",
-  "shell:gh repo delete",
-  "shell:gh release create",
-  "shell:gh release delete",
-  "shell:gh ruleset",
-  "shell:gh workflow",
-  "shell:git push",
-];

--- a/src/strategies/issue-comment-reply.ts
+++ b/src/strategies/issue-comment-reply.ts
@@ -13,6 +13,12 @@ import type { Strategy } from "./types.js";
 
 const TIMEOUT_MS = 1800 * 1000;
 
+// Source reply has to land on the original issue to keep the thread from
+// going silent after side effects already executed. Retry a small fixed
+// number of times before giving up so a transient GitHub API hiccup does
+// not strand the receipts in the task log alone.
+const SOURCE_REPLY_MAX_ATTEMPTS = 3;
+
 export const issueCommentReplyStrategy: Strategy = {
   policies: {
     uses: { codex: true },
@@ -120,13 +126,45 @@ export const issueCommentReplyStrategy: Strategy = {
         ? `${envelope.replyComment}\n\n${appendix}`
         : envelope.replyComment;
 
-    try {
-      await tk.github.postIssueComment(task.repo, task.source.number, finalReply);
-    } catch (error) {
+    let sourceReplyError: unknown;
+    for (let attempt = 1; attempt <= SOURCE_REPLY_MAX_ATTEMPTS; attempt++) {
+      signal.throwIfAborted();
+      try {
+        await tk.github.postIssueComment(
+          task.repo,
+          task.source.number,
+          finalReply,
+        );
+        sourceReplyError = undefined;
+        if (attempt > 1) {
+          await tk.log.write(
+            `issue-comment-reply: source reply posted on attempt ${attempt}/${SOURCE_REPLY_MAX_ATTEMPTS}`,
+          );
+        }
+        break;
+      } catch (error) {
+        sourceReplyError = error;
+        await tk.log.write(
+          `issue-comment-reply: source reply attempt ${attempt}/${SOURCE_REPLY_MAX_ATTEMPTS} failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+
+    if (sourceReplyError !== undefined) {
+      // Side effects in `additionalActions` are already on GitHub. Persist
+      // the intended reply body (with receipts) to the task log so the
+      // owner can recover the would-have-been-posted reply manually.
+      await tk.log.write(
+        `issue-comment-reply: giving up after ${SOURCE_REPLY_MAX_ATTEMPTS} attempts; intended reply body follows so executed side effects are not silently lost:\n${finalReply}`,
+      );
       return {
         status: "failed",
-        errorSummary: `issue-comment-reply: failed to post source reply: ${
-          error instanceof Error ? error.message : String(error)
+        errorSummary: `issue-comment-reply: failed to post source reply after ${SOURCE_REPLY_MAX_ATTEMPTS} attempts: ${
+          sourceReplyError instanceof Error
+            ? sourceReplyError.message
+            : String(sourceReplyError)
         }`,
       };
     }

--- a/src/strategies/issue-comment-reply.ts
+++ b/src/strategies/issue-comment-reply.ts
@@ -1,18 +1,44 @@
 import { header, mapAiFailure, ok } from "./_shared/helpers.js";
-import { OBSERVE_ALLOWED, REPLY_DISALLOWED } from "./_shared/tool-presets.js";
+import {
+  COLLECT_ONLY_ALLOWED,
+} from "./_shared/tool-presets.js";
+import {
+  ISSUE_COMMENT_REPLY_OUTPUT_SCHEMA,
+  formatFailedActionReceipt,
+  formatSucceededActionReceipt,
+  parseIssueCommentReplyEnvelope,
+  renderAdditionalActionReceipts,
+} from "./_shared/reply-actions.js";
 import type { Strategy } from "./types.js";
 
 const TIMEOUT_MS = 1800 * 1000;
 
 export const issueCommentReplyStrategy: Strategy = {
-  policies: { uses: { codex: true }, supersedeOnSameSource: true, timeoutMs: TIMEOUT_MS },
+  policies: {
+    uses: { codex: true },
+    supersedeOnSameSource: true,
+    timeoutMs: TIMEOUT_MS,
+  },
   run: async (task, tk, signal) => {
+    if (task.source.kind !== "issue") {
+      return {
+        status: "failed",
+        errorSummary: "issue-comment-reply requires an issue source",
+      };
+    }
+
     signal.throwIfAborted();
     await using ws = await tk.workspace.prepareObserve(task);
     void ws;
 
     signal.throwIfAborted();
     const ctx = await tk.github.fetchContext(task);
+    if (ctx.kind !== "issue") {
+      return {
+        status: "failed",
+        errorSummary: "issue-comment-reply requires issue context",
+      };
+    }
 
     signal.throwIfAborted();
     const result = await tk.ai.run({
@@ -22,18 +48,89 @@ export const issueCommentReplyStrategy: Strategy = {
         { kind: "file", path: "_common/engineering-stance" },
         { kind: "file", path: "personas/reply" },
         { kind: "literal", text: header(task, ctx) },
-        { kind: "file", path: "modes/observe" },
+        { kind: "file", path: "modes/reply-structured" },
         { kind: "file", path: "_common/omgr-docs" },
         { kind: "context", key: "issue-body" },
         { kind: "context", key: "issue-comments" },
         { kind: "context", key: "linked-refs" },
         { kind: "user", text: task.additionalInstructions ?? "" },
       ],
-      allowedTools: OBSERVE_ALLOWED,
-      disallowedTools: REPLY_DISALLOWED,
+      allowedTools: COLLECT_ONLY_ALLOWED,
       timeoutMs: TIMEOUT_MS,
+      outputSchema: ISSUE_COMMENT_REPLY_OUTPUT_SCHEMA,
     });
 
-    return result.kind === "succeeded" ? ok() : mapAiFailure(result);
+    if (result.kind !== "succeeded") {
+      return mapAiFailure(result);
+    }
+
+    let envelope;
+    try {
+      envelope = parseIssueCommentReplyEnvelope(result.stdout, task.source.number);
+    } catch (error) {
+      return {
+        status: "failed",
+        errorSummary: error instanceof Error ? error.message : String(error),
+      };
+    }
+
+    const receipts: string[] = [];
+    for (const action of envelope.additionalActions) {
+      signal.throwIfAborted();
+      try {
+        switch (action.kind) {
+          case "create_issue": {
+            const created = await tk.github.createIssue(
+              task.repo,
+              action.title,
+              action.body,
+            );
+            receipts.push(formatSucceededActionReceipt(action, created));
+            break;
+          }
+          case "close_issue":
+            await tk.github.closeIssue(task.repo, action.issueNumber);
+            receipts.push(formatSucceededActionReceipt(action));
+            break;
+          case "comment":
+            if (action.targetKind === "issue") {
+              await tk.github.postIssueComment(
+                task.repo,
+                action.targetNumber,
+                action.body,
+              );
+            } else {
+              await tk.github.postPrComment(
+                task.repo,
+                action.targetNumber,
+                action.body,
+              );
+            }
+            receipts.push(formatSucceededActionReceipt(action));
+            break;
+        }
+      } catch (error) {
+        receipts.push(formatFailedActionReceipt(action, error));
+      }
+    }
+
+    const appendix = renderAdditionalActionReceipts(receipts);
+    const finalReply =
+      appendix.length > 0
+        ? `${envelope.replyComment}\n\n${appendix}`
+        : envelope.replyComment;
+
+    try {
+      await tk.github.postIssueComment(task.repo, task.source.number, finalReply);
+    } catch (error) {
+      return {
+        status: "failed",
+        errorSummary: `issue-comment-reply: failed to post source reply: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      };
+    }
+
+    return ok();
   },
 };

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -29,6 +29,17 @@ export interface AiRunOptions {
   allowedTools?: readonly string[];
   disallowedTools?: readonly string[];
   timeoutMs?: number;
+  /**
+   * JSON Schema (OpenAI structured-output subset: `anyOf` is allowed but
+   * `oneOf` is rejected; every property must appear in `required`; every
+   * object needs `additionalProperties: false`) describing the model's
+   * final output. When set, the runner enforces the schema natively if
+   * it can (codex via `--output-schema`) and the resulting stdout is the
+   * schema-conformant JSON string. Runners without native support throw,
+   * so strategies should only set this when routing to a tool that
+   * supports it.
+   */
+  outputSchema?: object;
 }
 
 export type AiRunResult =
@@ -60,6 +71,12 @@ export interface Toolkit {
       prNumber: number,
       body: string,
     ): Promise<void>;
+    createIssue(
+      repo: RepoRef,
+      title: string,
+      body: string,
+    ): Promise<{ number: number; url: string }>;
+    closeIssue(repo: RepoRef, issueNumber: number): Promise<void>;
   };
   workspace: {
     prepareObserve(

--- a/tests/unit/claude-tool-runner.test.ts
+++ b/tests/unit/claude-tool-runner.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import { describe, test } from "node:test";
 import type {
   ProcessRunner,
@@ -158,6 +159,23 @@ describe("ClaudeToolRunner.run", () => {
     assert.deepEqual(calls[0]?.args, ["-p"]);
   });
 
+  test("throws when outputSchema is provided (claude runner does not yet support structured output)", async () => {
+    const { processRunner, calls } = makeProcessRunner();
+    const runner = new ClaudeToolRunner({ ...baseRunnerOptions, processRunner });
+
+    await assert.rejects(
+      runner.run({
+        task,
+        workspacePath: "/tmp/ws",
+        prompt: "hi",
+        outputSchema: { type: "object" },
+      }),
+      /outputSchema is not yet supported/,
+    );
+    // Process must not be invoked when the runner refuses up front.
+    assert.equal(calls.length, 0);
+  });
+
   test("returns succeeded on exit 0", async () => {
     const { processRunner } = makeProcessRunner({ exitCode: 0, stdout: "done" });
     const runner = new ClaudeToolRunner({ ...baseRunnerOptions, processRunner });
@@ -219,28 +237,34 @@ describe("ClaudeToolRunner.run", () => {
 describe("ClaudeToolRunner.cleanupArtifacts", () => {
   test("removes the encoded projects dir for a workspace inside workspacesDir", async () => {
     const { fs, calls } = makeFs();
+    const workspacesDir = "/home/ubuntu/runner-deploy/var/workspaces";
+    const claudeHome = "/home/ubuntu/.claude";
+    const workspacePath =
+      "/home/ubuntu/runner-deploy/var/workspaces/task_1777391732491_qc7ixeyy";
     const runner = new ClaudeToolRunner({
       ...baseRunnerOptions,
       processRunner: makeProcessRunner().processRunner,
-      workspacesDir: "/home/ubuntu/runner-deploy/var/workspaces",
-      claudeHome: "/home/ubuntu/.claude",
+      workspacesDir,
+      claudeHome,
       fs,
     });
 
-    await runner.cleanupArtifacts(
-      "/home/ubuntu/runner-deploy/var/workspaces/task_1777391732491_qc7ixeyy",
+    await runner.cleanupArtifacts(workspacePath);
+
+    const target = path.join(
+      claudeHome,
+      "projects",
+      encodeProjectsDirName(path.resolve(workspacePath)),
     );
 
     assert.deepEqual(calls, [
       {
         op: "stat",
-        target:
-          "/home/ubuntu/.claude/projects/-home-ubuntu-runner-deploy-var-workspaces-task-1777391732491-qc7ixeyy",
+        target,
       },
       {
         op: "rm",
-        target:
-          "/home/ubuntu/.claude/projects/-home-ubuntu-runner-deploy-var-workspaces-task-1777391732491-qc7ixeyy",
+        target,
       },
     ]);
   });

--- a/tests/unit/claude-tool-runner.test.ts
+++ b/tests/unit/claude-tool-runner.test.ts
@@ -159,21 +159,67 @@ describe("ClaudeToolRunner.run", () => {
     assert.deepEqual(calls[0]?.args, ["-p"]);
   });
 
-  test("throws when outputSchema is provided (claude runner does not yet support structured output)", async () => {
+  test("with outputSchema: passes --json-schema with serialized schema and surfaces stdout as succeeded", async () => {
+    const replyJson =
+      '{"replyComment":"hi","additionalActions":[],"reasoning":"ack"}';
+    const { processRunner, calls } = makeProcessRunner({
+      exitCode: 0,
+      stdout: replyJson,
+    });
+    const runner = new ClaudeToolRunner({ ...baseRunnerOptions, processRunner });
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["replyComment"],
+      properties: { replyComment: { type: "string" } },
+    } as const;
+
+    const result = await runner.run({
+      task,
+      workspacePath: "/tmp/ws",
+      prompt: "decide",
+      outputSchema: schema,
+    });
+
+    const args = calls[0]?.args ?? [];
+    const flagIdx = args.indexOf("--json-schema");
+    assert.ok(flagIdx >= 0, "--json-schema must be passed");
+    assert.deepEqual(JSON.parse(args[flagIdx + 1] ?? ""), schema);
+
+    assert.equal(result.kind, "succeeded");
+    if (result.kind === "succeeded") {
+      assert.equal(result.stdout, replyJson);
+    }
+  });
+
+  test("with outputSchema: returns failed when stdout is empty despite exit 0", async () => {
+    const { processRunner } = makeProcessRunner({
+      exitCode: 0,
+      stdout: "   \n",
+      stderr: "",
+    });
+    const runner = new ClaudeToolRunner({ ...baseRunnerOptions, processRunner });
+
+    const result = await runner.run({
+      task,
+      workspacePath: "/tmp/ws",
+      prompt: "hi",
+      outputSchema: { type: "object" },
+    });
+
+    assert.equal(result.kind, "failed");
+    if (result.kind !== "failed") return;
+    assert.equal(result.exitCode, 0);
+    assert.match(result.stderr, /empty stdout despite outputSchema/);
+  });
+
+  test("without outputSchema: --json-schema is absent from args", async () => {
     const { processRunner, calls } = makeProcessRunner();
     const runner = new ClaudeToolRunner({ ...baseRunnerOptions, processRunner });
 
-    await assert.rejects(
-      runner.run({
-        task,
-        workspacePath: "/tmp/ws",
-        prompt: "hi",
-        outputSchema: { type: "object" },
-      }),
-      /outputSchema is not yet supported/,
-    );
-    // Process must not be invoked when the runner refuses up front.
-    assert.equal(calls.length, 0);
+    await runner.run({ task, workspacePath: "/tmp/ws", prompt: "hi" });
+
+    assert.ok(!(calls[0]?.args ?? []).includes("--json-schema"));
   });
 
   test("returns succeeded on exit 0", async () => {

--- a/tests/unit/codex-tool-runner.test.ts
+++ b/tests/unit/codex-tool-runner.test.ts
@@ -295,6 +295,31 @@ describe("CodexToolRunner.run", () => {
     }
   });
 
+  test("with outputSchema: returns failed when last-message file is empty", async () => {
+    const codexDir = path.join("/tmp/ws", ".codex");
+    const lastMsgFile = path.join(codexDir, "last-message.txt");
+    const { fs } = makeFs({ readFiles: { [lastMsgFile]: "   \n" } });
+    const { processRunner } = makeProcessRunner({
+      exitCode: 0,
+      stdout: "codex verbose log",
+      stderr: "",
+    });
+    const runner = new CodexToolRunner({ command: "codex", processRunner, fs });
+
+    const result = await runner.run({
+      task,
+      workspacePath: "/tmp/ws",
+      prompt: "x",
+      outputSchema: { type: "object" },
+    });
+
+    assert.equal(result.kind, "failed");
+    if (result.kind !== "failed") return;
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, "codex verbose log");
+    assert.match(result.stderr, /empty last-message\.txt/);
+  });
+
   test("without outputSchema: schema file is not written and --output-schema is absent", async () => {
     const { fs, calls: fsCalls } = makeFs();
     const { processRunner, calls: procCalls } = makeProcessRunner();

--- a/tests/unit/codex-tool-runner.test.ts
+++ b/tests/unit/codex-tool-runner.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import { describe, test } from "node:test";
 import type {
   ProcessRunner,
@@ -26,12 +27,14 @@ const task: TaskRecord = {
 };
 
 interface FsCall {
-  op: "mkdir" | "writeFile" | "rm";
+  op: "mkdir" | "writeFile" | "readFile" | "rm";
   target: string;
   contents?: string;
 }
 
-function makeFs(): { fs: CodexFs; calls: FsCall[] } {
+function makeFs(
+  options: { readFiles?: Record<string, string>; readFileMissing?: boolean } = {},
+): { fs: CodexFs; calls: FsCall[] } {
   const calls: FsCall[] = [];
   const fs: CodexFs = {
     mkdir: async (target, _opts) => {
@@ -40,6 +43,19 @@ function makeFs(): { fs: CodexFs; calls: FsCall[] } {
     },
     writeFile: async (target, contents) => {
       calls.push({ op: "writeFile", target, contents });
+    },
+    readFile: async (target) => {
+      calls.push({ op: "readFile", target });
+      if (options.readFileMissing === true) {
+        const err = new Error(`ENOENT: ${target}`);
+        (err as NodeJS.ErrnoException).code = "ENOENT";
+        throw err;
+      }
+      const stub = options.readFiles?.[target];
+      if (stub !== undefined) {
+        return stub;
+      }
+      return "";
     },
     rm: async (target, _opts) => {
       calls.push({ op: "rm", target });
@@ -129,6 +145,7 @@ describe("CodexToolRunner.run", () => {
     const { fs, calls: fsCalls } = makeFs();
     const { processRunner } = makeProcessRunner();
     const runner = new CodexToolRunner({ command: "codex", processRunner, fs });
+    const rulesDir = path.join("/tmp/ws", ".codex", "rules");
 
     await runner.run({
       task,
@@ -141,8 +158,8 @@ describe("CodexToolRunner.run", () => {
     const mkdirCall = fsCalls.find((c) => c.op === "mkdir");
     const writeCall = fsCalls.find((c) => c.op === "writeFile");
 
-    assert.equal(mkdirCall?.target, "/tmp/ws/.codex/rules");
-    assert.equal(writeCall?.target, "/tmp/ws/.codex/rules/default.rules");
+    assert.equal(mkdirCall?.target, rulesDir);
+    assert.equal(writeCall?.target, path.join(rulesDir, "default.rules"));
     assert.match(writeCall?.contents ?? "", /pattern = \["gh"\][^]*decision = "allow"/);
     assert.match(
       writeCall?.contents ?? "",
@@ -205,6 +222,95 @@ describe("CodexToolRunner.run", () => {
     assert.equal(result.kind, "succeeded");
   });
 
+  test("with outputSchema: writes schema file, passes --output-schema and -o, returns last-message contents as stdout", async () => {
+    const lastMessageBody = '{"decision_type":"no_action","reasoning":"ack only"}';
+    const codexDir = path.join("/tmp/ws", ".codex");
+    const schemaFile = path.join(codexDir, "output.schema.json");
+    const lastMsgFile = path.join(codexDir, "last-message.txt");
+    const { fs, calls: fsCalls } = makeFs({
+      readFiles: { [lastMsgFile]: lastMessageBody },
+    });
+    const { processRunner, calls: procCalls } = makeProcessRunner({
+      exitCode: 0,
+      stdout: "raw stdout (should be replaced)",
+    });
+    const runner = new CodexToolRunner({ command: "codex", processRunner, fs });
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["decision_type"],
+      properties: { decision_type: { type: "string" } },
+    } as const;
+
+    const result = await runner.run({
+      task,
+      workspacePath: "/tmp/ws",
+      prompt: "decide",
+      outputSchema: schema,
+    });
+
+    // mkdir for .codex + writeFile for the schema file
+    const mkdirTargets = fsCalls.filter((c) => c.op === "mkdir").map((c) => c.target);
+    const writeTargets = fsCalls.filter((c) => c.op === "writeFile");
+    assert.ok(mkdirTargets.includes(codexDir));
+    const schemaWrite = writeTargets.find((c) => c.target === schemaFile);
+    assert.ok(schemaWrite, "schema file must be written");
+    assert.deepEqual(JSON.parse(schemaWrite!.contents ?? ""), schema);
+
+    // CLI args include --output-schema <path> and -o <last-message>
+    const args = procCalls[0]?.args ?? [];
+    const schemaIdx = args.indexOf("--output-schema");
+    assert.ok(schemaIdx >= 0, "--output-schema must be passed");
+    assert.equal(args[schemaIdx + 1], schemaFile);
+    const oIdx = args.indexOf("-o");
+    assert.ok(oIdx >= 0, "-o must be passed");
+    assert.equal(args[oIdx + 1], lastMsgFile);
+
+    // -- separator and prompt remain at the tail
+    assert.equal(args[args.length - 2], "--");
+    assert.equal(args[args.length - 1], "decide");
+
+    // stdout should be the last-message file contents, not the raw stdout
+    assert.equal(result.kind, "succeeded");
+    if (result.kind === "succeeded") {
+      assert.equal(result.stdout, lastMessageBody);
+    }
+  });
+
+  test("with outputSchema: falls back to raw stdout when last-message file is missing", async () => {
+    const { fs } = makeFs({ readFileMissing: true });
+    const { processRunner } = makeProcessRunner({ exitCode: 0, stdout: "fallback" });
+    const runner = new CodexToolRunner({ command: "codex", processRunner, fs });
+
+    const result = await runner.run({
+      task,
+      workspacePath: "/tmp/ws",
+      prompt: "x",
+      outputSchema: { type: "object" },
+    });
+
+    assert.equal(result.kind, "succeeded");
+    if (result.kind === "succeeded") {
+      assert.equal(result.stdout, "fallback");
+    }
+  });
+
+  test("without outputSchema: schema file is not written and --output-schema is absent", async () => {
+    const { fs, calls: fsCalls } = makeFs();
+    const { processRunner, calls: procCalls } = makeProcessRunner();
+    const runner = new CodexToolRunner({ command: "codex", processRunner, fs });
+
+    await runner.run({ task, workspacePath: "/tmp/ws", prompt: "x" });
+
+    const writes = fsCalls.filter(
+      (c) => c.op === "writeFile" && c.target.endsWith("output.schema.json"),
+    );
+    assert.equal(writes.length, 0);
+    const args = procCalls[0]?.args ?? [];
+    assert.ok(!args.includes("--output-schema"));
+    assert.ok(!args.includes("-o"));
+  });
+
   test("detects rate-limit phrases on a non-zero exit", async () => {
     const { fs } = makeFs();
     const { processRunner } = makeProcessRunner({
@@ -239,7 +345,7 @@ describe("CodexToolRunner.cleanupArtifacts", () => {
 
     assert.deepEqual(
       calls.filter((c) => c.op === "rm"),
-      [{ op: "rm", target: "/tmp/ws/.codex" }],
+      [{ op: "rm", target: path.join("/tmp/ws", ".codex") }],
     );
   });
 });

--- a/tests/unit/issue-comment-reply-strategy.test.ts
+++ b/tests/unit/issue-comment-reply-strategy.test.ts
@@ -1,12 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import type { GitHubSourceContext } from "../../src/domain/github.js";
-import type { TaskRecord } from "../../src/domain/task.js";
+import type { RepoRef, TaskRecord } from "../../src/domain/task.js";
 import { issueCommentReplyStrategy } from "../../src/strategies/issue-comment-reply.js";
-import {
-  OBSERVE_ALLOWED,
-  REPLY_DISALLOWED,
-} from "../../src/strategies/_shared/tool-presets.js";
+import { COLLECT_ONLY_ALLOWED } from "../../src/strategies/_shared/tool-presets.js";
+import { ISSUE_COMMENT_REPLY_OUTPUT_SCHEMA } from "../../src/strategies/_shared/reply-actions.js";
 import type {
   AiRunOptions,
   AiRunResult,
@@ -29,18 +27,46 @@ const task: TaskRecord = {
 const issueContext: GitHubSourceContext = {
   kind: "issue",
   title: "How should we structure the new module?",
-  body: "Question body…",
+  body: "Question body",
   comments: [{ author: "alice", body: "follow-up question" }],
   linkedRefs: { closes: [], bodyMentions: [] },
 };
 
-function makeToolkit(replyResult: AiRunResult): {
+interface IssueCommentCall {
+  issueNumber: number;
+  body: string;
+}
+
+interface PrCommentCall {
+  prNumber: number;
+  body: string;
+}
+
+interface CreateIssueCall {
+  title: string;
+  body: string;
+}
+
+function makeToolkit(options: {
+  replyResult: AiRunResult;
+  createIssueResult?: { number: number; url: string };
+  createIssueError?: Error;
+  closeIssueError?: Error;
+  issueCommentError?: Error;
+  prCommentError?: Error;
+}): {
   tk: Toolkit;
   aiCalls: AiRunOptions[];
-  postedIssueComments: Array<{ issueNumber: number; body: string }>;
+  postedIssueComments: IssueCommentCall[];
+  postedPrComments: PrCommentCall[];
+  createdIssues: CreateIssueCall[];
+  closedIssues: number[];
 } {
   const aiCalls: AiRunOptions[] = [];
-  const postedIssueComments: Array<{ issueNumber: number; body: string }> = [];
+  const postedIssueComments: IssueCommentCall[] = [];
+  const postedPrComments: PrCommentCall[] = [];
+  const createdIssues: CreateIssueCall[] = [];
+  const closedIssues: number[] = [];
 
   const observeWs: DisposableWorkspace = {
     path: "/tmp/observe",
@@ -59,9 +85,33 @@ function makeToolkit(replyResult: AiRunResult): {
       fetchContext: async () => issueContext,
       getDefaultBranch: async () => "main",
       postIssueComment: async (_repo, issueNumber, body) => {
+        if (options.issueCommentError !== undefined) {
+          throw options.issueCommentError;
+        }
         postedIssueComments.push({ issueNumber, body });
       },
-      postPrComment: async () => {},
+      postPrComment: async (_repo, prNumber, body) => {
+        if (options.prCommentError !== undefined) {
+          throw options.prCommentError;
+        }
+        postedPrComments.push({ prNumber, body });
+      },
+      createIssue: async (_repo, title, body) => {
+        if (options.createIssueError !== undefined) {
+          throw options.createIssueError;
+        }
+        createdIssues.push({ title, body });
+        return options.createIssueResult ?? {
+          number: 501,
+          url: "https://github.com/octo/repo/issues/501",
+        };
+      },
+      closeIssue: async (_repo, issueNumber) => {
+        if (options.closeIssueError !== undefined) {
+          throw options.closeIssueError;
+        }
+        closedIssues.push(issueNumber);
+      },
     },
     workspace: {
       prepareObserve: async () => observeWs,
@@ -71,14 +121,34 @@ function makeToolkit(replyResult: AiRunResult): {
     ai: {
       run: async (opts) => {
         aiCalls.push(opts);
-        return replyResult;
+        return options.replyResult;
       },
     },
     log: {
       write: async () => {},
     },
   };
-  return { tk, aiCalls, postedIssueComments };
+
+  return {
+    tk,
+    aiCalls,
+    postedIssueComments,
+    postedPrComments,
+    createdIssues,
+    closedIssues,
+  };
+}
+
+function replyEnvelope(payload?: {
+  replyComment?: string;
+  reasoning?: string;
+  additionalActions?: readonly object[];
+}): string {
+  return JSON.stringify({
+    replyComment: payload?.replyComment ?? "Here is the answer.",
+    reasoning: payload?.reasoning ?? "This is the most direct response.",
+    additionalActions: payload?.additionalActions ?? [],
+  });
 }
 
 describe("issueCommentReplyStrategy", () => {
@@ -87,11 +157,14 @@ describe("issueCommentReplyStrategy", () => {
     assert.equal(issueCommentReplyStrategy.policies.supersedeOnSameSource, true);
   });
 
-  test("invokes ai.run exactly once with the reply persona, observe mode, and observe-allowed + reply-disallowed", async () => {
-    const { tk, aiCalls, postedIssueComments } = makeToolkit({
-      kind: "succeeded",
-      stdout: "직답: ...",
-    });
+  test("invokes ai.run with the reply persona, structured reply mode, collect-only permissions, and the output schema", async () => {
+    const { tk, aiCalls, postedIssueComments, createdIssues, closedIssues } =
+      makeToolkit({
+        replyResult: {
+          kind: "succeeded",
+          stdout: replyEnvelope(),
+        },
+      });
 
     const result = await issueCommentReplyStrategy.run(
       task,
@@ -103,47 +176,200 @@ describe("issueCommentReplyStrategy", () => {
     assert.equal(aiCalls.length, 1);
 
     const call = aiCalls[0]!;
-    // tool override is omitted because policies.uses is single-tool; the
-    // toolkit infers codex from the declared set.
     assert.equal(call.tool, undefined);
-    assert.equal(call.allowedTools, OBSERVE_ALLOWED);
-    assert.equal(call.disallowedTools, REPLY_DISALLOWED);
+    assert.equal(call.allowedTools, COLLECT_ONLY_ALLOWED);
+    assert.deepEqual(call.outputSchema, ISSUE_COMMENT_REPLY_OUTPUT_SCHEMA);
 
-    // Reply persona is wired in; the old architect persona is not.
     const personaPaths = call.prompt
       .filter((f) => f.kind === "file" && f.path.startsWith("personas/"))
       .map((f) => (f.kind === "file" ? f.path : ""));
     assert.deepEqual(personaPaths, ["personas/reply"]);
     assert.ok(
-      !personaPaths.includes("personas/architect"),
-      "architect persona must not appear in reply prompt",
+      call.prompt.some(
+        (f) => f.kind === "file" && f.path === "modes/reply-structured",
+      ),
+      "structured reply mode prompt must be present",
     );
-
-    // Observe mode is preserved (option-2 contract: AI posts the reply itself).
     assert.ok(
-      call.prompt.some((f) => f.kind === "file" && f.path === "modes/observe"),
-      "observe mode prompt must be present",
+      !call.prompt.some((f) => f.kind === "file" && f.path === "modes/observe"),
+      "observe mode must not be present",
     );
 
-    // Strategy must not post via runner; AI is responsible for `gh issue comment`.
+    assert.deepEqual(createdIssues, []);
+    assert.deepEqual(closedIssues, []);
+    assert.deepEqual(postedIssueComments, [
+      { issueNumber: 42, body: "Here is the answer." },
+    ]);
+  });
+
+  test("executes create_issue, close_issue, and comment actions and appends receipts to the source reply", async () => {
+    const { tk, postedIssueComments, postedPrComments, createdIssues, closedIssues } =
+      makeToolkit({
+        replyResult: {
+          kind: "succeeded",
+          stdout: replyEnvelope({
+            replyComment: "Completed the follow-up actions.",
+            additionalActions: [
+              {
+                kind: "create_issue",
+                title: "Follow-up: capture edge cases",
+                body: "Track the uncovered edge cases here.",
+              },
+              { kind: "close_issue", issueNumber: 77 },
+              {
+                kind: "comment",
+                targetKind: "pull_request",
+                targetNumber: 88,
+                body: "Please see the linked issue for the next step.",
+              },
+            ],
+          }),
+        },
+      });
+
+    const result = await issueCommentReplyStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    assert.deepEqual(result, { status: "succeeded" });
+    assert.deepEqual(createdIssues, [
+      {
+        title: "Follow-up: capture edge cases",
+        body: "Track the uncovered edge cases here.",
+      },
+    ]);
+    assert.deepEqual(closedIssues, [77]);
+    assert.deepEqual(postedPrComments, [
+      {
+        prNumber: 88,
+        body: "Please see the linked issue for the next step.",
+      },
+    ]);
+    assert.equal(postedIssueComments.length, 1);
+    const finalReply = postedIssueComments[0]!;
+    assert.equal(finalReply.issueNumber, 42);
+    assert.match(finalReply.body, /Completed the follow-up actions\./);
+    assert.match(finalReply.body, /Opened follow-up issue #501/);
+    assert.match(finalReply.body, /Closed issue #77/);
+    assert.match(finalReply.body, /Commented on pull request #88/);
+  });
+
+  test("rejects an empty replyComment", async () => {
+    const { tk, postedIssueComments } = makeToolkit({
+      replyResult: {
+        kind: "succeeded",
+        stdout: replyEnvelope({ replyComment: "   " }),
+      },
+    });
+
+    const result = await issueCommentReplyStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    assert.equal(result.status, "failed");
+    if (result.status !== "failed") return;
+    assert.match(result.errorSummary, /replyComment/i);
     assert.equal(postedIssueComments.length, 0);
   });
 
-  test("disallowedTools blocks code-mutating gh subcommands and git push", () => {
-    assert.ok(REPLY_DISALLOWED.includes("shell:gh pr merge"));
-    assert.ok(REPLY_DISALLOWED.includes("shell:gh repo edit"));
-    assert.ok(REPLY_DISALLOWED.includes("shell:gh repo delete"));
-    assert.ok(REPLY_DISALLOWED.includes("shell:gh release create"));
-    assert.ok(REPLY_DISALLOWED.includes("shell:gh release delete"));
-    assert.ok(REPLY_DISALLOWED.includes("shell:gh ruleset"));
-    assert.ok(REPLY_DISALLOWED.includes("shell:gh workflow"));
-    assert.ok(REPLY_DISALLOWED.includes("shell:git push"));
+  test("rejects additionalActions.comment when it targets the source issue", async () => {
+    const { tk, postedIssueComments, postedPrComments } = makeToolkit({
+      replyResult: {
+        kind: "succeeded",
+        stdout: replyEnvelope({
+          additionalActions: [
+            {
+              kind: "comment",
+              targetKind: "issue",
+              targetNumber: 42,
+              body: "This should be rejected.",
+            },
+          ],
+        }),
+      },
+    });
+
+    const result = await issueCommentReplyStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    assert.equal(result.status, "failed");
+    if (result.status !== "failed") return;
+    assert.match(result.errorSummary, /source issue/i);
+    assert.equal(postedIssueComments.length, 0);
+    assert.equal(postedPrComments.length, 0);
+  });
+
+  test("reports malformed JSON as a failure", async () => {
+    const { tk, postedIssueComments } = makeToolkit({
+      replyResult: {
+        kind: "succeeded",
+        stdout: "{not valid json",
+      },
+    });
+
+    const result = await issueCommentReplyStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    assert.equal(result.status, "failed");
+    if (result.status !== "failed") return;
+    assert.match(result.errorSummary, /parse/i);
+    assert.equal(postedIssueComments.length, 0);
+  });
+
+  test("continues after an additional action fails and includes the failure receipt in the source reply", async () => {
+    const { tk, postedIssueComments, createdIssues } = makeToolkit({
+      closeIssueError: new Error("permission denied"),
+      replyResult: {
+        kind: "succeeded",
+        stdout: replyEnvelope({
+          replyComment: "I tried both actions.",
+          additionalActions: [
+            { kind: "close_issue", issueNumber: 77 },
+            {
+              kind: "create_issue",
+              title: "Fallback tracking issue",
+              body: "Used because closing failed.",
+            },
+          ],
+        }),
+      },
+    });
+
+    const result = await issueCommentReplyStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    assert.deepEqual(result, { status: "succeeded" });
+    assert.deepEqual(createdIssues, [
+      {
+        title: "Fallback tracking issue",
+        body: "Used because closing failed.",
+      },
+    ]);
+    assert.equal(postedIssueComments.length, 1);
+    assert.match(postedIssueComments[0]!.body, /Failed to close issue #77/);
+    assert.match(postedIssueComments[0]!.body, /permission denied/);
+    assert.match(postedIssueComments[0]!.body, /Opened follow-up issue #501/);
   });
 
   test("forwards rate_limited from ai.run with toolName preserved", async () => {
     const { tk, postedIssueComments } = makeToolkit({
-      kind: "rate_limited",
-      toolName: "codex",
+      replyResult: {
+        kind: "rate_limited",
+        toolName: "codex",
+      },
     });
 
     const result = await issueCommentReplyStrategy.run(
@@ -160,8 +386,10 @@ describe("issueCommentReplyStrategy", () => {
 
   test("forwards failed from ai.run with errorSummary preserved", async () => {
     const { tk, postedIssueComments } = makeToolkit({
-      kind: "failed",
-      errorSummary: "codex crashed",
+      replyResult: {
+        kind: "failed",
+        errorSummary: "codex crashed",
+      },
     });
 
     const result = await issueCommentReplyStrategy.run(
@@ -179,7 +407,12 @@ describe("issueCommentReplyStrategy", () => {
   test("respects an aborted signal at strategy entry", async () => {
     const ac = new AbortController();
     ac.abort();
-    const { tk, aiCalls } = makeToolkit({ kind: "succeeded", stdout: "x" });
+    const { tk, aiCalls } = makeToolkit({
+      replyResult: {
+        kind: "succeeded",
+        stdout: replyEnvelope(),
+      },
+    });
 
     await assert.rejects(
       issueCommentReplyStrategy.run(task, tk, ac.signal),

--- a/tests/unit/issue-comment-reply-strategy.test.ts
+++ b/tests/unit/issue-comment-reply-strategy.test.ts
@@ -53,6 +53,10 @@ function makeToolkit(options: {
   createIssueError?: Error;
   closeIssueError?: Error;
   issueCommentError?: Error;
+  // When set, the first `issueCommentFailureCount` calls to
+  // postIssueComment throw `issueCommentError`; subsequent calls succeed.
+  // Lets tests exercise the source-reply retry loop.
+  issueCommentFailureCount?: number;
   prCommentError?: Error;
 }): {
   tk: Toolkit;
@@ -61,12 +65,16 @@ function makeToolkit(options: {
   postedPrComments: PrCommentCall[];
   createdIssues: CreateIssueCall[];
   closedIssues: number[];
+  logMessages: string[];
+  issueCommentAttempts: () => number;
 } {
   const aiCalls: AiRunOptions[] = [];
   const postedIssueComments: IssueCommentCall[] = [];
   const postedPrComments: PrCommentCall[] = [];
   const createdIssues: CreateIssueCall[] = [];
   const closedIssues: number[] = [];
+  const logMessages: string[] = [];
+  let issueCommentAttempts = 0;
 
   const observeWs: DisposableWorkspace = {
     path: "/tmp/observe",
@@ -85,8 +93,17 @@ function makeToolkit(options: {
       fetchContext: async () => issueContext,
       getDefaultBranch: async () => "main",
       postIssueComment: async (_repo, issueNumber, body) => {
-        if (options.issueCommentError !== undefined) {
-          throw options.issueCommentError;
+        issueCommentAttempts += 1;
+        const failureCount = options.issueCommentFailureCount;
+        const shouldFail =
+          failureCount !== undefined
+            ? issueCommentAttempts <= failureCount
+            : options.issueCommentError !== undefined;
+        if (shouldFail) {
+          throw (
+            options.issueCommentError ??
+            new Error("postIssueComment forced failure")
+          );
         }
         postedIssueComments.push({ issueNumber, body });
       },
@@ -125,7 +142,9 @@ function makeToolkit(options: {
       },
     },
     log: {
-      write: async () => {},
+      write: async (message: string) => {
+        logMessages.push(message);
+      },
     },
   };
 
@@ -136,6 +155,8 @@ function makeToolkit(options: {
     postedPrComments,
     createdIssues,
     closedIssues,
+    logMessages,
+    issueCommentAttempts: () => issueCommentAttempts,
   };
 }
 
@@ -362,6 +383,112 @@ describe("issueCommentReplyStrategy", () => {
     assert.match(postedIssueComments[0]!.body, /Failed to close issue #77/);
     assert.match(postedIssueComments[0]!.body, /permission denied/);
     assert.match(postedIssueComments[0]!.body, /Opened follow-up issue #501/);
+  });
+
+  test("retries the source reply post and succeeds when the third attempt lands", async () => {
+    const {
+      tk,
+      postedIssueComments,
+      logMessages,
+      issueCommentAttempts,
+    } = makeToolkit({
+      issueCommentError: new Error("503 service unavailable"),
+      issueCommentFailureCount: 2,
+      replyResult: {
+        kind: "succeeded",
+        stdout: replyEnvelope({ replyComment: "Eventually delivered." }),
+      },
+    });
+
+    const result = await issueCommentReplyStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    assert.deepEqual(result, { status: "succeeded" });
+    assert.equal(issueCommentAttempts(), 3);
+    assert.equal(postedIssueComments.length, 1);
+    assert.equal(postedIssueComments[0]!.body, "Eventually delivered.");
+    assert.equal(
+      logMessages.filter((m) => /attempt 1\/3 failed/.test(m)).length,
+      1,
+    );
+    assert.equal(
+      logMessages.filter((m) => /attempt 2\/3 failed/.test(m)).length,
+      1,
+    );
+    assert.ok(
+      logMessages.some((m) => /posted on attempt 3\/3/.test(m)),
+      "successful retry must be logged",
+    );
+    assert.ok(
+      !logMessages.some((m) => /giving up/.test(m)),
+      "successful retry must not log a giving-up line",
+    );
+  });
+
+  test("gives up after 3 failed source-reply attempts and logs the intended body with receipts", async () => {
+    const {
+      tk,
+      postedIssueComments,
+      postedPrComments,
+      logMessages,
+      issueCommentAttempts,
+    } = makeToolkit({
+      issueCommentError: new Error("502 bad gateway"),
+      replyResult: {
+        kind: "succeeded",
+        stdout: replyEnvelope({
+          replyComment: "Side effects ran but reply might fail.",
+          additionalActions: [
+            {
+              kind: "comment",
+              targetKind: "pull_request",
+              targetNumber: 88,
+              body: "PR notice already posted.",
+            },
+          ],
+        }),
+      },
+    });
+
+    const result = await issueCommentReplyStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    assert.equal(result.status, "failed");
+    if (result.status !== "failed") return;
+    assert.match(result.errorSummary, /after 3 attempts/);
+    assert.match(result.errorSummary, /502 bad gateway/);
+
+    assert.equal(issueCommentAttempts(), 3);
+    assert.equal(postedIssueComments.length, 0);
+    assert.equal(postedPrComments.length, 1);
+
+    for (const attempt of [1, 2, 3]) {
+      assert.equal(
+        logMessages.filter((m) =>
+          new RegExp(`attempt ${attempt}/3 failed`).test(m),
+        ).length,
+        1,
+        `attempt ${attempt} failure must be logged exactly once`,
+      );
+    }
+    const givingUp = logMessages.find((m) => /giving up/.test(m));
+    assert.ok(givingUp, "must log a giving-up line carrying the intended body");
+    assert.match(
+      givingUp!,
+      /Side effects ran but reply might fail\./,
+      "intended replyComment must be in the giving-up log",
+    );
+    assert.match(
+      givingUp!,
+      /Commented on pull request #88/,
+      "side-effect receipts must be in the giving-up log",
+    );
   });
 
   test("forwards rate_limited from ai.run with toolName preserved", async () => {

--- a/tests/unit/issue-initial-review-strategy.test.ts
+++ b/tests/unit/issue-initial-review-strategy.test.ts
@@ -80,6 +80,11 @@ function makeToolkit(options: {
       postPrComment: async (_repo, prNumber, body) => {
         postedPrComments.push({ prNumber, body });
       },
+      createIssue: async () => ({
+        number: 501,
+        url: "https://github.com/octo/repo/issues/501",
+      }),
+      closeIssue: async () => {},
     },
     workspace: {
       prepareObserve: async () => observeWs,

--- a/tests/unit/toolkit.test.ts
+++ b/tests/unit/toolkit.test.ts
@@ -71,6 +71,11 @@ function buildToolkit(opts: {
     postPullRequestComment: async () => {
       throw new Error("not used");
     },
+    createIssue: async () => ({
+      number: 501,
+      url: "https://github.com/octo/repo/issues/501",
+    }),
+    closeIssue: async () => {},
   } as unknown as GitHubClient;
   const workspaceManager = {
     prepareObserveWorkspace: async () => ({
@@ -227,6 +232,31 @@ describe("toolkit.ai.run — prompt render wiring", () => {
 
     assert.equal(renderCalls.length, 1);
     assert.equal(renderCalls[0]?.workspacePath, "/tmp/ws");
+  });
+
+  test("forwards outputSchema to the selected runner", async () => {
+    const { factory, calls } = buildToolkit({ declared: ["codex"] });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["replyComment"],
+      properties: {
+        replyComment: { type: "string" },
+      },
+    };
+
+    await tk.ai.run({
+      prompt: [{ kind: "literal", text: "hi" }],
+      outputSchema: schema,
+    });
+
+    assert.deepEqual(calls[0]?.input.outputSchema, schema);
   });
 });
 


### PR DESCRIPTION
﻿Closes #103

## 요약
- `issue-comment-reply`를 AI 직접 `gh` 실행형에서 구조화 출력 + runner 실행형으로 전환했습니다.
- `replyComment` / `additionalActions` / `reasoning` 계약과 `create_issue` / `close_issue` / `comment` 액션 dispatch를 추가했습니다.
- Codex structured output 배선과 관련 테스트를 보강하고, runner 테스트의 경로 기대값을 OS 중립으로 정리했습니다.

## 변경의 의도
`issue-comment-reply`는 기존에 AI가 직접 댓글을 달아야만 실제 부수효과가 발생했고, 전략 코드는 프로세스 성공만 확인했습니다. 그래서 모델이 침묵하거나 `gh` 쓰기를 건너뛰어도 task는 성공처럼 끝날 수 있었습니다.

이번 변경은 `issue-comment-reply`를 `replyComment` + `additionalActions` JSON 계약으로 바꾸고, 실제 GitHub side effect는 runner가 결정론적으로 실행하도록 옮깁니다. 댓글 본문은 항상 source issue에 남고, follow-up issue 생성/issue close/다른 thread comment는 별도 action receipt로 기록됩니다.

## 리뷰 포인트
- `src/strategies/issue-comment-reply.ts:44`
  Codex structured output 호출 이후 envelope 파싱, action dispatch, source reply 게시까지의 주 흐름입니다. `tests/unit/issue-comment-reply-strategy.test.ts`에서 성공/실패/partial failure 경로를 같이 검증했습니다.
- `src/strategies/_shared/reply-actions.ts:30`
  reply envelope schema와 도메인 검증이 모여 있습니다. 특히 빈 `replyComment` 차단과 source issue self-comment 차단이 핵심입니다. 같은 테스트 파일에서 malformed JSON, empty reply, self-comment rejection을 확인했습니다.
- `src/infra/tool/codex-tool-runner.ts:47`
  `outputSchema`를 Codex CLI로 내리고 `last-message.txt`를 읽어 structured stdout으로 되돌리는 seam입니다. `tests/unit/codex-tool-runner.test.ts`와 `tests/unit/toolkit.test.ts`로 배선을 검증했습니다.

## 의도적으로 안 한 것
- `pr-review-comment`는 이번 PR 범위에서 제외했습니다.
- label/assignee 같은 추가 GitHub mutation은 넣지 않았습니다.
- action chaining, 새로 만든 issue를 같은 run에서 다시 참조하는 흐름은 지원하지 않습니다.

## 트레이드오프
`additionalActions` 중 일부가 실패해도 source issue reply는 계속 게시하고, 실패 사실을 receipt로 덧붙입니다. #103의 핵심이 “source thread가 침묵으로 끝나지 않게 만들기”였기 때문에, side action 일부 실패보다 source reply 보장을 우선했습니다.

## 테스트
- `npm run build`
- `npm test`
