### PR TITLE
fix(rate-limit): close two dispatch races (closes #109, #110)

### DIFF
--- a/src/daemon/runner-daemon.ts
+++ b/src/daemon/runner-daemon.ts
@@ -438,6 +438,18 @@ export class RunnerDaemon {
     task: TaskRecord,
     toolName: string,
   ): Promise<void> {
+    // Order matters: tick() reads pausedTools (state.json) and queued/ (task
+    // files) independently. If the task reappears in queued/ before the pause
+    // is on disk, a racing tick re-dispatches it and burns another 429
+    // (issue #109). Pause first, requeue second; GitHub notification is slow
+    // and stays at the tail so it never widens the critical-path window.
+    const store = this.dependencies.rateLimit?.store;
+    let pausedUntil: number | undefined;
+    if (store !== undefined) {
+      pausedUntil = this.now() + this.rateLimitCooldownMs;
+      await store.pause(toolName, pausedUntil);
+    }
+
     try {
       await this.dependencies.queueStore.revertToQueued(task.taskId);
     } catch (error) {
@@ -455,23 +467,7 @@ export class RunnerDaemon {
       }
     }
 
-    const onRateLimited = this.dependencies.notifications?.onRateLimited;
-    if (onRateLimited !== undefined) {
-      try {
-        await onRateLimited(task);
-      } catch (error) {
-        this.warn(
-          `[daemon] notifyTaskRateLimited threw: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
-    }
-
-    const store = this.dependencies.rateLimit?.store;
-    if (store !== undefined) {
-      const pausedUntil = this.now() + this.rateLimitCooldownMs;
-      await store.pause(toolName, pausedUntil);
+    if (pausedUntil !== undefined) {
       console.warn(
         `[daemon] rate-limited task=${task.taskId} tool=${toolName} pausedUntil=${new Date(pausedUntil).toISOString()}`,
       );
@@ -487,6 +483,19 @@ export class RunnerDaemon {
         task.taskId,
         `rate-limited; reverted to queued (no state store configured)`,
       );
+    }
+
+    const onRateLimited = this.dependencies.notifications?.onRateLimited;
+    if (onRateLimited !== undefined) {
+      try {
+        await onRateLimited(task);
+      } catch (error) {
+        this.warn(
+          `[daemon] notifyTaskRateLimited threw: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
     }
   }
 

--- a/src/domain/rules/scheduling.ts
+++ b/src/domain/rules/scheduling.ts
@@ -12,21 +12,35 @@ export interface SelectNextTasksInput {
   toolsForTask: (task: TaskRecord) => readonly string[];
 }
 
-// Pure FIFO scheduling against the concurrency budget, skipping any
-// queued task whose agent is rate-limit-paused. Same-repo mutate
-// serialization is no longer needed: branch names now include a
-// taskId suffix so concurrent mutate runs cannot collide on a branch,
-// and same-source duplicate triggers are handled by supersede-on-enqueue
-// rather than by holding back the second task in the scheduler.
+// Pure FIFO scheduling against the concurrency budget. Two skip rules:
+//   1. Tool is rate-limit-paused.
+//   2. Tool is already claimed by another in-flight task — either currently
+//      running, or selected earlier in this same tick (issue #110). Without
+//      this cap, two queued tasks sharing a tool got dispatched together;
+//      the first task's eventual 429 wrote a pause too late to stop the
+//      second from also hitting 429. Per-tool budget = 1.
+// Multi-tool strategies (e.g. issue-initial-review with claude + codex)
+// claim every tool they declare. Persona steps run sequentially inside a
+// task, so we cannot assume the task is using "only" one tool right now —
+// any concurrent same-strategy task could collide on either side.
+// Same-repo mutate serialization is intentionally not enforced here: branch
+// names include a taskId suffix so concurrent mutate runs cannot collide on
+// a branch, and same-source duplicate triggers are handled by
+// supersede-on-enqueue.
 export function selectNextTasks(input: SelectNextTasksInput): string[] {
   const pausedTools = input.pausedTools ?? new Set<string>();
-  const runningCount = input.tasks.filter(
-    (task) => task.status === "running",
-  ).length;
-  const slots = input.maxConcurrency - runningCount;
+  const running = input.tasks.filter((task) => task.status === "running");
+  const slots = input.maxConcurrency - running.length;
 
   if (slots <= 0) {
     return [];
+  }
+
+  const inFlightTools = new Set<string>();
+  for (const task of running) {
+    for (const tool of input.toolsForTask(task)) {
+      inFlightTools.add(tool);
+    }
   }
 
   const selected: string[] = [];
@@ -38,7 +52,13 @@ export function selectNextTasks(input: SelectNextTasksInput): string[] {
     if (taskTools.some((t) => pausedTools.has(t))) {
       continue;
     }
+    if (taskTools.some((t) => inFlightTools.has(t))) {
+      continue;
+    }
     selected.push(task.taskId);
+    for (const tool of taskTools) {
+      inFlightTools.add(tool);
+    }
   }
   return selected;
 }

--- a/tests/unit/runner-daemon.test.ts
+++ b/tests/unit/runner-daemon.test.ts
@@ -95,6 +95,7 @@ describe("RunnerDaemon", () => {
     const calls: string[] = [];
     let currentTask = createTask("queued");
     const pauses: Array<{ tool: string; pausedUntil: number }> = [];
+    const notifyOrder: string[] = [];
 
     const daemon = new RunnerDaemon({
       queueStore: {
@@ -141,10 +142,17 @@ describe("RunnerDaemon", () => {
         store: {
           loadActivePauses: async () => new Map(),
           pause: async (tool, pausedUntil) => {
+            calls.push(`pause:${tool}`);
             pauses.push({ tool, pausedUntil });
           },
         },
         cooldownMs: 60_000,
+      },
+      notifications: {
+        onRateLimited: async () => {
+          notifyOrder.push("notify");
+          calls.push("notify:rate-limited");
+        },
       },
       clock: { now: () => 5_000_000 },
     });
@@ -157,6 +165,25 @@ describe("RunnerDaemon", () => {
     ]);
     assert.ok(calls.includes("revert:task_1"));
     assert.ok(calls.some((c) => c.startsWith("log:task_1:rate-limited")));
+
+    // Critical ordering invariant (issue #109): the tool pause must hit disk
+    // before the task reappears in queued/, otherwise a racing tick will
+    // re-dispatch the same task and burn another 429. GitHub notification is
+    // slow and must stay at the tail so it never widens that window.
+    const pauseIdx = calls.indexOf("pause:claude");
+    const revertIdx = calls.indexOf("revert:task_1");
+    const notifyIdx = calls.indexOf("notify:rate-limited");
+    assert.ok(pauseIdx !== -1, "expected store.pause to be called");
+    assert.ok(revertIdx !== -1, "expected revertToQueued to be called");
+    assert.ok(notifyIdx !== -1, "expected onRateLimited to be called");
+    assert.ok(
+      pauseIdx < revertIdx,
+      `pause must precede revertToQueued, got pause=${pauseIdx} revert=${revertIdx} (calls=${calls.join(",")})`,
+    );
+    assert.ok(
+      revertIdx < notifyIdx,
+      `revertToQueued must precede onRateLimited, got revert=${revertIdx} notify=${notifyIdx} (calls=${calls.join(",")})`,
+    );
   });
 
   test("notifies task failure when execution throws a non rate-limit error", async () => {

--- a/tests/unit/scheduler-service.test.ts
+++ b/tests/unit/scheduler-service.test.ts
@@ -26,12 +26,16 @@ describe("SchedulerService", () => {
   test("schedules same-repo work concurrently - branch suffix removes the collision", () => {
     const scheduler = new SchedulerService({ maxConcurrency: 2 });
 
+    // Different tools so the per-tool cap (#110) is not what's being tested
+    // here. The point of this case is that two tasks targeting the same repo
+    // are NOT serialized at the scheduler level.
     const selected = scheduler.selectNextTasks({
       tasks: [
         createTask("task_running", "running", "repo-a"),
         createTask("task_queued", "queued", "repo-a"),
       ],
-      toolsForTask: claudeOnly,
+      toolsForTask: (task) =>
+        task.taskId === "task_running" ? ["claude"] : ["codex"],
     });
 
     assert.deepEqual(selected, ["task_queued"]);
@@ -71,13 +75,21 @@ describe("SchedulerService", () => {
   test("fills free slots with executable queued work in created order", () => {
     const scheduler = new SchedulerService({ maxConcurrency: 2 });
 
+    // Distinct tools per task so slot-filling is what's measured, not the
+    // per-tool cap (#110). With same-tool tasks, only one would be picked.
+    const toolByTask: Record<string, readonly string[]> = {
+      task_1: ["claude"],
+      task_2: ["codex"],
+      task_3: ["gemini"],
+    };
+
     const selected = scheduler.selectNextTasks({
       tasks: [
         createTask("task_1", "queued", "repo-a"),
         createTask("task_2", "queued", "repo-a"),
         createTask("task_3", "queued", "repo-b"),
       ],
-      toolsForTask: claudeOnly,
+      toolsForTask: (task) => toolByTask[task.taskId] ?? [],
     });
 
     assert.deepEqual(selected, ["task_1", "task_2"]);
@@ -93,6 +105,98 @@ describe("SchedulerService", () => {
         createTask("task_q", "queued", "repo-c"),
       ],
       toolsForTask: claudeOnly,
+    });
+
+    assert.deepEqual(selected, []);
+  });
+
+  test("caps queued same-tool dispatches to one per tick (#110)", () => {
+    // Two queued tasks both wanting claude. Without the per-tool cap, both
+    // would be dispatched in one tick and both would race to a 429.
+    const scheduler = new SchedulerService({ maxConcurrency: 2 });
+
+    const selected = scheduler.selectNextTasks({
+      tasks: [
+        createTask("task_1", "queued", "repo-a"),
+        createTask("task_2", "queued", "repo-b"),
+      ],
+      toolsForTask: claudeOnly,
+    });
+
+    assert.deepEqual(selected, ["task_1"]);
+  });
+
+  test("skips queued task when its tool is already used by a running task (#110)", () => {
+    const scheduler = new SchedulerService({ maxConcurrency: 2 });
+
+    const selected = scheduler.selectNextTasks({
+      tasks: [
+        createTask("task_running", "running", "repo-a"),
+        createTask("task_queued", "queued", "repo-b"),
+      ],
+      toolsForTask: claudeOnly,
+    });
+
+    assert.deepEqual(selected, []);
+  });
+
+  test("schedules queued task when running task uses a different tool (#110)", () => {
+    const scheduler = new SchedulerService({ maxConcurrency: 2 });
+
+    const selected = scheduler.selectNextTasks({
+      tasks: [
+        createTask("task_running", "running", "repo-a"),
+        createTask("task_queued", "queued", "repo-b"),
+      ],
+      toolsForTask: (task) =>
+        task.taskId === "task_running" ? ["claude"] : ["codex"],
+    });
+
+    assert.deepEqual(selected, ["task_queued"]);
+  });
+
+  test("skips later same-tool queued tasks but picks distinct-tool queued tasks (#110)", () => {
+    // Queue: [claude, codex, claude]. concurrency=2. The first claude task
+    // claims claude, codex slot is free, second claude is skipped.
+    const scheduler = new SchedulerService({ maxConcurrency: 2 });
+
+    const toolByTask: Record<string, readonly string[]> = {
+      task_1: ["claude"],
+      task_2: ["codex"],
+      task_3: ["claude"],
+    };
+
+    const selected = scheduler.selectNextTasks({
+      tasks: [
+        createTask("task_1", "queued", "repo-a"),
+        createTask("task_2", "queued", "repo-a"),
+        createTask("task_3", "queued", "repo-a"),
+      ],
+      toolsForTask: (task) => toolByTask[task.taskId] ?? [],
+    });
+
+    assert.deepEqual(selected, ["task_1", "task_2"]);
+  });
+
+  test("multi-tool running task claims every declared tool (#110)", () => {
+    // issue-initial-review style: declares claude + codex even though one
+    // task only runs them sequentially. A queued task using either tool
+    // must wait until the multi-tool task finishes.
+    const scheduler = new SchedulerService({ maxConcurrency: 2 });
+
+    const toolByTask: Record<string, readonly string[]> = {
+      task_running: ["claude", "codex"],
+      task_q_claude: ["claude"],
+      task_q_codex: ["codex"],
+    };
+
+    const selected = scheduler.selectNextTasks({
+      tasks: [
+        createTask("task_running", "running", "repo-a"),
+        createTask("task_q_claude", "queued", "repo-a"),
+        createTask("task_q_codex", "queued", "repo-a"),
+      ],
+      toolsForTask: (task) => toolByTask[task.taskId] ?? [],
     });
 
     assert.deepEqual(selected, []);


### PR DESCRIPTION
## Summary

Two race conditions caused the daemon to repeatedly dispatch tasks at a rate-limited tool, burning AI budget and prolonging pause windows. Both are addressed here.

- **#109** — `handleRateLimit` previously did `revertToQueued` → GitHub notify (slow) → `store.pause`. Between revertToQueued and pause, the task was already visible in `queued/` while `state.json` still showed the tool as unpaused, so the next 2 s tick re-dispatched the same task and immediately hit another 429. Reorder to **pause → requeue → notify**: any tick that observes the requeued task now also observes the pause.
- **#110** — `selectNextTasks` honored `maxConcurrency` and `pausedTools` but did not bound how many tasks could share a tool. With concurrency=2 and a queue of two claude tasks, a single tick dispatched both; the first task's eventual 429 wrote a pause too late to stop the second from also hitting 429. Track an `inFlightTools` set built from currently-running tasks and extend it as queued tasks are selected. Multi-tool strategies (e.g. `issue-initial-review` = claude+codex) claim every declared tool because persona steps are sequential within a task and any concurrent same-strategy task can collide on either side.

Per-tool budget = 1 trades nominal same-tool parallelism (was 2) for not burning 429s on every cascade. Different-tool tasks still parallelize up to `maxConcurrency`.

## Test plan

- [x] `npm run build` — typecheck clean
- [x] `npm test` — 279/279 (was 274, +5 new tests)
  - Existing rate-limit handler test now asserts the ordering invariant (`pause` < `revert` < `notify`)
  - New scheduler tests cover: same-tool cap, running blocks queued same-tool, running with a different tool does NOT block, FIFO with mixed tools skips later same-tool, multi-tool running task claims every declared tool
- [ ] Production log check after deploy: the `same-task-twice-within-seconds` cluster and the `same-tick concurrent dispatch on same tool` pattern (e.g. `issue-initial-review` queueing 3 codex personas) should disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)