### PR TITLE
feat(rate-limit): AI step checkpoint cache (closes #137)

### DIFF
--- a/src/daemon/runner-daemon.ts
+++ b/src/daemon/runner-daemon.ts
@@ -378,7 +378,7 @@ export class RunnerDaemon {
     }
 
     if (result.status === "rate_limited") {
-      await this.handleRateLimit(task, result.toolName);
+      await this.handleRateLimit(task, result.toolNames);
       return;
     }
 
@@ -436,18 +436,27 @@ export class RunnerDaemon {
 
   private async handleRateLimit(
     task: TaskRecord,
-    toolName: string,
+    toolNames: readonly string[],
   ): Promise<void> {
     // Order matters: tick() reads pausedTools (state.json) and queued/ (task
     // files) independently. If the task reappears in queued/ before the pause
     // is on disk, a racing tick re-dispatches it and burns another 429
-    // (issue #109). Pause first, requeue second; GitHub notification is slow
-    // and stays at the tail so it never widens the critical-path window.
+    // (issue #109). Pause every rate-limited tool first, requeue second;
+    // GitHub notification is slow and stays at the tail so it never widens
+    // the critical-path window.
+    //
+    // toolNames may include several entries when a strategy fans out
+    // parallel AI calls (e.g. issue-initial-review's claude+codex personas)
+    // and more than one tool 429'd in the same run. All of them must be
+    // paused before the task goes back into queued/, otherwise the next
+    // tick will dispatch the still-unpaused tool again.
     const store = this.dependencies.rateLimit?.store;
     let pausedUntil: number | undefined;
-    if (store !== undefined) {
+    if (store !== undefined && toolNames.length > 0) {
       pausedUntil = this.now() + this.rateLimitCooldownMs;
-      await store.pause(toolName, pausedUntil);
+      for (const toolName of toolNames) {
+        await store.pause(toolName, pausedUntil);
+      }
     }
 
     try {
@@ -467,17 +476,19 @@ export class RunnerDaemon {
       }
     }
 
+    const toolList = toolNames.join(",");
     if (pausedUntil !== undefined) {
+      const pausedUntilIso = new Date(pausedUntil).toISOString();
       console.warn(
-        `[daemon] rate-limited task=${task.taskId} tool=${toolName} pausedUntil=${new Date(pausedUntil).toISOString()}`,
+        `[daemon] rate-limited task=${task.taskId} tools=${toolList} pausedUntil=${pausedUntilIso}`,
       );
       await this.dependencies.logStore.write(
         task.taskId,
-        `rate-limited; paused tool '${toolName}' until ${new Date(pausedUntil).toISOString()}`,
+        `rate-limited; paused tools [${toolList}] until ${pausedUntilIso}`,
       );
     } else {
       console.warn(
-        `[daemon] rate-limited task=${task.taskId} tool=${toolName} (no state store)`,
+        `[daemon] rate-limited task=${task.taskId} tools=${toolList} (no state store)`,
       );
       await this.dependencies.logStore.write(
         task.taskId,

--- a/src/daemon/runner-daemon.ts
+++ b/src/daemon/runner-daemon.ts
@@ -1,3 +1,4 @@
+import type { CheckpointStore } from "../domain/ports/checkpoint-store.js";
 import type { LogStore } from "../domain/ports/log-store.js";
 import type { QueueStore } from "../domain/ports/queue-store.js";
 import type { TaskRecord } from "../domain/task.js";
@@ -8,6 +9,17 @@ import type { ExecuteResult } from "../strategies/types.js";
 export interface RunnerDaemonDependencies {
   queueStore: QueueStore;
   schedulerService: SchedulerService;
+  /**
+   * Optional cache for AI step results (#137). When wired:
+   *   - drop(taskId) is called on every terminal transition (succeeded /
+   *     failed / superseded), so a re-enqueued task starts with a clean
+   *     slate;
+   *   - sweep(activeTaskIds) is called at startup to remove orphan
+   *     directories left behind by crashes.
+   * rate_limited transitions intentionally leave the cache in place so
+   * the next retry can serve cache hits.
+   */
+  checkpointStore?: CheckpointStore;
   // Runs a task to completion. The daemon owns when to call this; the
   // composition root supplies the implementation (typically `getStrategy(...)
   // .run(task, toolkitFactory.create(task), signal)`). Tests inject a stub.
@@ -119,19 +131,31 @@ export class RunnerDaemon {
     await this.dependencies.queueStore.recoverRunningTasks(
       "daemon interrupted before completion",
     );
-    const cleanupOrphanWorkspaces =
-      this.dependencies.janitor?.cleanupOrphanWorkspaces;
-    if (cleanupOrphanWorkspaces !== undefined) {
-      try {
+
+    // Active set is shared between workspace cleanup and checkpoint sweep:
+    // both want "tasks the daemon will still touch" (queued + running). It
+    // is computed AFTER recoverRunningTasks so any tasks just rolled to
+    // failed are correctly treated as orphans.
+    let activeTaskIds: ReadonlySet<string> | undefined;
+    const ensureActive = async (): Promise<ReadonlySet<string>> => {
+      if (activeTaskIds === undefined) {
         const tasks = await this.dependencies.queueStore.listTasks();
-        const active = new Set(
+        activeTaskIds = new Set(
           tasks
             .filter(
               (task) => task.status === "queued" || task.status === "running",
             )
             .map((task) => task.taskId),
         );
-        const removed = await cleanupOrphanWorkspaces(active);
+      }
+      return activeTaskIds;
+    };
+
+    const cleanupOrphanWorkspaces =
+      this.dependencies.janitor?.cleanupOrphanWorkspaces;
+    if (cleanupOrphanWorkspaces !== undefined) {
+      try {
+        const removed = await cleanupOrphanWorkspaces(await ensureActive());
         if (removed > 0) {
           console.log(
             `[daemon] cleanupOrphanWorkspaces removed ${removed} orphan workspace dir(s)`,
@@ -145,6 +169,26 @@ export class RunnerDaemon {
         );
       }
     }
+
+    if (this.dependencies.checkpointStore !== undefined) {
+      try {
+        const dropped = await this.dependencies.checkpointStore.sweep(
+          await ensureActive(),
+        );
+        if (dropped > 0) {
+          console.log(
+            `[daemon] checkpoint sweep dropped ${dropped} orphan dir(s)`,
+          );
+        }
+      } catch (error) {
+        this.warn(
+          `[daemon] checkpoint sweep threw: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+
     await this.dependencies.logStore.cleanupExpired();
     await this.maybePrune(true);
   }
@@ -216,6 +260,10 @@ export class RunnerDaemon {
       return;
     }
 
+    // Terminal transition: drop the old task's AI checkpoint cache. The
+    // replacement task has its own taskId and will start with no cache.
+    await this.dropCheckpoints(oldTaskId);
+
     const onSuperseded = this.dependencies.notifications?.onSuperseded;
     if (onSuperseded === undefined) {
       return;
@@ -281,6 +329,7 @@ export class RunnerDaemon {
         console.warn(
           `[daemon] recovered stale running task=${task.taskId} from=running to=failed startedAt=${task.startedAt} ageMs=${ageMs}`,
         );
+        await this.dropCheckpoints(task.taskId);
       } catch (error) {
         this.warn(
           `[daemon] sweepStaleRunning completeTask failed task=${task.taskId} from=running to=failed: ${
@@ -432,6 +481,11 @@ export class RunnerDaemon {
         // logStore failure is non-fatal; daemon must keep going.
       }
     }
+
+    // Terminal transition: drop the task's AI checkpoint cache. rate_limited
+    // returns earlier (above) and intentionally skips this — the next retry
+    // is supposed to reuse the cache.
+    await this.dropCheckpoints(task.taskId);
   }
 
   private async handleRateLimit(
@@ -507,6 +561,28 @@ export class RunnerDaemon {
           }`,
         );
       }
+    }
+  }
+
+  /**
+   * Best-effort cleanup of a task's AI checkpoint cache on terminal
+   * transition. No-op when no checkpointStore is wired. Failures are
+   * logged and swallowed: the task is already terminal in the queue, so a
+   * leftover cache directory is at worst disk noise that startup sweep
+   * picks up next time.
+   */
+  private async dropCheckpoints(taskId: string): Promise<void> {
+    if (this.dependencies.checkpointStore === undefined) {
+      return;
+    }
+    try {
+      await this.dependencies.checkpointStore.drop(taskId);
+    } catch (error) {
+      this.warn(
+        `[daemon] checkpoint drop failed task=${taskId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
 

--- a/src/domain/ports/checkpoint-store.ts
+++ b/src/domain/ports/checkpoint-store.ts
@@ -1,0 +1,41 @@
+/**
+ * Per-task cache of successful AI step results so a rate-limit retry can
+ * skip steps that already completed. The toolkit reads before each
+ * `tk.ai.run({ stepKey })` and writes on success; the daemon drops the
+ * task's directory on terminal transition (succeeded / failed / superseded)
+ * and sweeps orphan directories at startup.
+ *
+ * The `fingerprint` field is a hash of every input that affects AI output
+ * (rendered prompt, tool, intensity, allowedTools, disallowedTools,
+ * outputSchema). Reads compare it against the current invocation's
+ * fingerprint so context changes between retries (e.g. issue body edited)
+ * invalidate stale results.
+ */
+export interface CheckpointEntry {
+  readonly stepKey: string;
+  readonly fingerprint: string;
+  readonly tool: string;
+  readonly succeededAt: string;
+  readonly stdout: string;
+}
+
+export interface CheckpointStore {
+  read(
+    taskId: string,
+    stepKey: string,
+  ): Promise<CheckpointEntry | undefined>;
+  write(taskId: string, entry: CheckpointEntry): Promise<void>;
+  /**
+   * Remove every checkpoint for the given task. Called on terminal
+   * transition. Idempotent — must not throw when the directory does
+   * not exist.
+   */
+  drop(taskId: string): Promise<void>;
+  /**
+   * Remove orphan task directories whose taskId is NOT in
+   * `activeTaskIds`. Called once at daemon startup. Returns the number
+   * of directories removed (best-effort; individual failures are logged
+   * and skipped).
+   */
+  sweep(activeTaskIds: ReadonlySet<string>): Promise<number>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import os from "node:os";
 import { RunnerDaemon } from "./daemon/runner-daemon.js";
 import { Runtime } from "./runtime.js";
+import { FileCheckpointStore } from "./infra/checkpoint/file-checkpoint-store.js";
 import { FileQueueStore } from "./infra/queue/file-queue-store.js";
 import { FileLogStore } from "./infra/logs/file-log-store.js";
 import { SchedulerService } from "./services/scheduler-service.js";
@@ -196,6 +197,10 @@ export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
     dataDir: path.join(runnerRoot, "var", "queue"),
   });
 
+  const checkpointStore = new FileCheckpointStore({
+    dataDir: path.join(runnerRoot, "var", "checkpoints"),
+  });
+
   const promptFragments = await loadPromptFragments({
     promptsDir: path.join(runnerRoot, "definitions", "prompts"),
   });
@@ -209,6 +214,7 @@ export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
     logStore,
     promptRenderer,
     toolsForTask,
+    checkpointStore,
   });
 
   const daemon = new RunnerDaemon({
@@ -223,6 +229,7 @@ export async function buildRuntimeFromEnvironment(): Promise<Runtime> {
     toolsForTask,
     logStore,
     pollIntervalMs,
+    checkpointStore,
     rateLimit: {
       store: rateLimitStateStore,
       cooldownMs: rateLimitCooldownMs,

--- a/src/infra/checkpoint/file-checkpoint-store.ts
+++ b/src/infra/checkpoint/file-checkpoint-store.ts
@@ -1,0 +1,206 @@
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import type {
+  CheckpointEntry,
+  CheckpointStore,
+} from "../../domain/ports/checkpoint-store.js";
+
+// Bumped only on schema changes. Reads of unknown versions return undefined
+// (cache miss); the writer overwrites with the current version on the next
+// success, so old data evaporates without an explicit migration.
+const CHECKPOINT_VERSION = 1;
+
+// Sibling of taskId-named directories. Picked outside any plausible taskId
+// pattern so `sweep` can skip it explicitly.
+const CORRUPT_DIR = "corrupt";
+
+interface PersistedCheckpoint {
+  version: number;
+  stepKey: string;
+  fingerprint: string;
+  tool: string;
+  succeededAt: string;
+  stdout: string;
+}
+
+export interface FileCheckpointStoreOptions {
+  dataDir: string;
+  warn?: (message: string) => void;
+}
+
+function isMissingFile(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
+// stepKey is strategy-authored and may contain path-unsafe characters
+// (slashes, dots, ...). Hash to a fixed 16-hex-char filename so the on-disk
+// layout is deterministic and safe regardless of the input.
+function stepFilename(stepKey: string): string {
+  return `${createHash("sha256").update(stepKey).digest("hex").slice(0, 16)}.json`;
+}
+
+export class FileCheckpointStore implements CheckpointStore {
+  private readonly dataDir: string;
+  private readonly warn: (message: string) => void;
+
+  constructor(options: FileCheckpointStoreOptions) {
+    this.dataDir = options.dataDir;
+    this.warn = options.warn ?? ((message) => console.warn(message));
+  }
+
+  async read(
+    taskId: string,
+    stepKey: string,
+  ): Promise<CheckpointEntry | undefined> {
+    const filePath = path.join(this.dataDir, taskId, stepFilename(stepKey));
+
+    let raw: string;
+    try {
+      raw = await readFile(filePath, "utf8");
+    } catch (error) {
+      if (isMissingFile(error)) {
+        return undefined;
+      }
+      throw error;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      await this.quarantine(taskId, stepKey, reason);
+      return undefined;
+    }
+
+    if (!isPersistedCheckpoint(parsed)) {
+      // Schema looks broken even if the file is valid JSON. Move it aside
+      // so future reads don't keep tripping on it, but the toolkit just
+      // sees a miss and recomputes — same outcome as a clean cold start.
+      const reason = `checkpoint payload missing required fields`;
+      await this.quarantine(taskId, stepKey, reason);
+      return undefined;
+    }
+
+    if (parsed.version !== CHECKPOINT_VERSION) {
+      // Forward-compatibility: unknown version => miss, no quarantine. The
+      // next successful run overwrites with the current schema.
+      return undefined;
+    }
+
+    return {
+      stepKey: parsed.stepKey,
+      fingerprint: parsed.fingerprint,
+      tool: parsed.tool,
+      succeededAt: parsed.succeededAt,
+      stdout: parsed.stdout,
+    };
+  }
+
+  async write(taskId: string, entry: CheckpointEntry): Promise<void> {
+    const dir = path.join(this.dataDir, taskId);
+    await mkdir(dir, { recursive: true });
+
+    const target = path.join(dir, stepFilename(entry.stepKey));
+    const tmp = `${target}.tmp`;
+
+    const payload: PersistedCheckpoint = {
+      version: CHECKPOINT_VERSION,
+      stepKey: entry.stepKey,
+      fingerprint: entry.fingerprint,
+      tool: entry.tool,
+      succeededAt: entry.succeededAt,
+      stdout: entry.stdout,
+    };
+
+    await writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
+    await rename(tmp, target);
+  }
+
+  async drop(taskId: string): Promise<void> {
+    const dir = path.join(this.dataDir, taskId);
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  async sweep(activeTaskIds: ReadonlySet<string>): Promise<number> {
+    let entries: string[];
+    try {
+      entries = await readdir(this.dataDir);
+    } catch (error) {
+      if (isMissingFile(error)) {
+        return 0;
+      }
+      throw error;
+    }
+
+    let dropped = 0;
+    for (const entry of entries) {
+      if (entry === CORRUPT_DIR) {
+        continue;
+      }
+      if (activeTaskIds.has(entry)) {
+        continue;
+      }
+      const target = path.join(this.dataDir, entry);
+      try {
+        await rm(target, { recursive: true, force: true });
+        dropped += 1;
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        this.warn(
+          `[file-checkpoint-store] sweep failed to remove ${target}: ${reason}`,
+        );
+      }
+    }
+    return dropped;
+  }
+
+  private async quarantine(
+    taskId: string,
+    stepKey: string,
+    reason: string,
+  ): Promise<void> {
+    const fromPath = path.join(this.dataDir, taskId, stepFilename(stepKey));
+    const corruptDir = path.join(this.dataDir, CORRUPT_DIR, taskId);
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const baseName = stepFilename(stepKey).replace(/\.json$/, "");
+    const toPath = path.join(corruptDir, `${baseName}.${stamp}.json`);
+
+    try {
+      await mkdir(corruptDir, { recursive: true });
+      await rename(fromPath, toPath);
+      this.warn(
+        `[file-checkpoint-store] quarantined corrupt checkpoint ${fromPath} -> ${toPath}: ${reason}`,
+      );
+    } catch (moveError) {
+      const moveReason =
+        moveError instanceof Error ? moveError.message : String(moveError);
+      this.warn(
+        `[file-checkpoint-store] failed to quarantine ${fromPath}: ${moveReason} (original parse error: ${reason})`,
+      );
+    }
+  }
+}
+
+function isPersistedCheckpoint(value: unknown): value is PersistedCheckpoint {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.version === "number" &&
+    typeof v.stepKey === "string" &&
+    typeof v.fingerprint === "string" &&
+    typeof v.tool === "string" &&
+    typeof v.succeededAt === "string" &&
+    typeof v.stdout === "string"
+  );
+}

--- a/src/services/toolkit.ts
+++ b/src/services/toolkit.ts
@@ -1,4 +1,6 @@
+import { createHash } from "node:crypto";
 import type { GitHubSourceContext } from "../domain/github.js";
+import type { CheckpointStore } from "../domain/ports/checkpoint-store.js";
 import type { GitHubClient } from "../domain/ports/github-client.js";
 import type { LogStore } from "../domain/ports/log-store.js";
 import type { WorkspaceManager } from "../domain/ports/workspace-manager.js";
@@ -28,6 +30,36 @@ export interface ToolkitFactoryOptions {
    * `cleanupArtifacts` across every declared tool on workspace dispose.
    */
   toolsForTask: (task: TaskRecord) => readonly string[];
+  /**
+   * When wired, ai.run reads from this store before calling the runner
+   * (cache hit on matching stepKey + fingerprint) and writes to it on
+   * success. Optional: leave undefined to disable caching entirely.
+   */
+  checkpointStore?: CheckpointStore;
+}
+
+/**
+ * Hash of every input that affects AI output. Used as the cache key
+ * second-level discriminator (after stepKey). A change in any of these
+ * inputs invalidates the prior cached result.
+ */
+function computeFingerprint(parts: {
+  promptText: string;
+  tool: string;
+  intensity: string | undefined;
+  allowedTools: readonly string[] | undefined;
+  disallowedTools: readonly string[] | undefined;
+  outputSchema: object | undefined;
+}): string {
+  const canonical = JSON.stringify({
+    promptText: parts.promptText,
+    tool: parts.tool,
+    intensity: parts.intensity ?? null,
+    allowedTools: parts.allowedTools ?? null,
+    disallowedTools: parts.disallowedTools ?? null,
+    outputSchema: parts.outputSchema ?? null,
+  });
+  return createHash("sha256").update(canonical).digest("hex");
 }
 
 export class ToolkitFactory {
@@ -257,6 +289,45 @@ class ToolkitImpl implements Toolkit {
         this.cachedContext,
         this.active.path,
       );
+
+      // Checkpoint cache: only active when both the strategy opted in via
+      // stepKey AND the toolkit was wired with a CheckpointStore. The
+      // fingerprint is recomputed every call so a cached entry is reused
+      // only when every input that can affect AI output matches what was
+      // saved earlier in this same task's lifecycle.
+      const checkpointStore = this.options.checkpointStore;
+      const cacheActive =
+        opts.stepKey !== undefined && checkpointStore !== undefined;
+      const fingerprint = cacheActive
+        ? computeFingerprint({
+            promptText,
+            tool: toolName,
+            intensity: opts.intensity,
+            allowedTools: opts.allowedTools,
+            disallowedTools: opts.disallowedTools,
+            outputSchema: opts.outputSchema,
+          })
+        : "";
+
+      if (
+        cacheActive &&
+        opts.stepKey !== undefined &&
+        checkpointStore !== undefined
+      ) {
+        const hit = await checkpointStore.read(this.task.taskId, opts.stepKey);
+        if (
+          hit !== undefined &&
+          hit.fingerprint === fingerprint &&
+          hit.tool === toolName
+        ) {
+          await this.options.logStore.write(
+            this.task.taskId,
+            `[ai.run] checkpoint hit step=${opts.stepKey} tool=${toolName}`,
+          );
+          return { kind: "succeeded", stdout: hit.stdout };
+        }
+      }
+
       const result = await this.options.toolRegistry.resolve(toolName).run({
         task: this.task,
         workspacePath: this.active.path,
@@ -276,6 +347,22 @@ class ToolkitImpl implements Toolkit {
         ...(this.signal !== undefined ? { signal: this.signal } : {}),
       });
       if (result.kind === "succeeded") {
+        // Cache only successful results. Failed and rate_limited responses
+        // are intentionally not persisted: a non-idempotent failure could
+        // mask a future success, and a 429 is purely transient.
+        if (
+          cacheActive &&
+          opts.stepKey !== undefined &&
+          checkpointStore !== undefined
+        ) {
+          await checkpointStore.write(this.task.taskId, {
+            stepKey: opts.stepKey,
+            fingerprint,
+            tool: toolName,
+            stdout: result.stdout,
+            succeededAt: new Date().toISOString(),
+          });
+        }
         return { kind: "succeeded", stdout: result.stdout };
       }
       if (result.kind === "rate_limited") {

--- a/src/strategies/_shared/helpers.ts
+++ b/src/strategies/_shared/helpers.ts
@@ -23,7 +23,7 @@ export function mapAiFailure(result: AiRunResult): ExecuteResult {
     return ok();
   }
   if (result.kind === "rate_limited") {
-    return { status: "rate_limited", toolName: result.toolName };
+    return { status: "rate_limited", toolNames: [result.toolName] };
   }
   return { status: "failed", errorSummary: result.errorSummary };
 }

--- a/src/strategies/issue-initial-review/index.ts
+++ b/src/strategies/issue-initial-review/index.ts
@@ -51,10 +51,17 @@ export const issueInitialReviewStrategy: Strategy = {
 
     // rate_limited wins over failed: the queue retries the whole task once
     // every tool is available again, so we surface that signal first.
+    // Personas run in parallel across multiple tools; collect every tool
+    // that rate-limited so the daemon pauses all of them and the next
+    // retry doesn't immediately burn another 429 on the still-hot tool.
+    const rateLimitedTools = new Set<string>();
     for (const { result } of settled) {
       if (result.kind === "rate_limited") {
-        return mapAiFailure(result);
+        rateLimitedTools.add(result.toolName);
       }
+    }
+    if (rateLimitedTools.size > 0) {
+      return { status: "rate_limited", toolNames: [...rateLimitedTools] };
     }
     for (const { result } of settled) {
       if (result.kind === "failed") {

--- a/src/strategies/issue-initial-review/index.ts
+++ b/src/strategies/issue-initial-review/index.ts
@@ -28,8 +28,13 @@ export const issueInitialReviewStrategy: Strategy = {
     signal.throwIfAborted();
     const settled = await Promise.all(
       PERSONAS.map(async (persona) => {
+        // stepKey opts this call into the toolkit checkpoint cache (#137):
+        // when one persona 429s and the daemon retries the task ~30 min
+        // later, the personas that already succeeded are served from disk
+        // and only the still-rate-limited one re-invokes its runner.
         const result = await tk.ai.run({
           tool: TOOL_MAP[persona.id],
+          stepKey: `persona/${persona.id}`,
           prompt: [
             { kind: "file", path: "_common/work-rules" },
             { kind: "file", path: "_common/tone" },

--- a/src/strategies/issue-initial-review/publisher.ts
+++ b/src/strategies/issue-initial-review/publisher.ts
@@ -33,6 +33,7 @@ export async function runPublisher(
 
   const result = await tk.ai.run({
     tool: PUBLISHER_TOOL,
+    stepKey: "publisher",
     prompt: [
       { kind: "file", path: "_common/work-rules" },
       { kind: "file", path: "_common/tone" },

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -111,7 +111,14 @@ export interface Toolkit {
 export type ExecuteResult =
   | { status: "succeeded" }
   | { status: "failed"; errorSummary: string }
-  | { status: "rate_limited"; toolName: string };
+  /**
+   * One or more tools that the strategy hit a rate-limit on during this
+   * run. A single AI call always reports one tool, but a strategy that
+   * fans out parallel calls across multiple tools (e.g. issue-initial-
+   * review's claude+codex personas) can collect rate-limits from several
+   * tools in one shot. The daemon pauses every tool listed here.
+   */
+  | { status: "rate_limited"; toolNames: readonly string[] };
 
 export interface StrategyPolicies {
   /**

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -48,6 +48,20 @@ export interface AiRunOptions {
    * supports it.
    */
   outputSchema?: object;
+  /**
+   * Opt-in cache key for this AI step within the task. When set AND a
+   * CheckpointStore is wired into the toolkit, the toolkit:
+   *   - reads the prior result from disk before invoking the runner
+   *     and returns it on a fingerprint match (skipping the AI call),
+   *   - writes the new result to disk on success.
+   * Must be deterministic across retries of the same task (e.g.
+   * `persona/architect`); UUIDs or timestamps defeat the cache. Strategy
+   * authors do NOT manage the fingerprint — the toolkit derives it from
+   * the rendered prompt + tool + intensity + allow/disallow lists +
+   * outputSchema, so a context change between retries (e.g. issue body
+   * edited) automatically invalidates a stale entry.
+   */
+  stepKey?: string;
 }
 
 export type AiRunResult =

--- a/tests/unit/file-checkpoint-store.test.ts
+++ b/tests/unit/file-checkpoint-store.test.ts
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "node:test";
+import { FileCheckpointStore } from "../../src/infra/checkpoint/file-checkpoint-store.js";
+
+function fileNameFor(stepKey: string): string {
+  return `${createHash("sha256").update(stepKey).digest("hex").slice(0, 16)}.json`;
+}
+
+function makeEntry(overrides: {
+  stepKey?: string;
+  fingerprint?: string;
+  tool?: string;
+  stdout?: string;
+} = {}) {
+  return {
+    stepKey: overrides.stepKey ?? "persona/architect",
+    fingerprint: overrides.fingerprint ?? "fp-1",
+    tool: overrides.tool ?? "claude",
+    succeededAt: "2026-05-05T12:00:00.000Z",
+    stdout: overrides.stdout ?? "analysis output",
+  };
+}
+
+describe("FileCheckpointStore", () => {
+  test("write then read returns the same entry", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({ dataDir: root });
+      const entry = makeEntry();
+      await store.write("task_1", entry);
+      const got = await store.read("task_1", entry.stepKey);
+      assert.deepEqual(got, entry);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("read on a non-existent task returns undefined", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({ dataDir: root });
+      const got = await store.read("task_missing", "step/x");
+      assert.equal(got, undefined);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("read on a task with no matching stepKey returns undefined", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({ dataDir: root });
+      await store.write("task_1", makeEntry({ stepKey: "step/a" }));
+      const got = await store.read("task_1", "step/b");
+      assert.equal(got, undefined);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("write is atomic — no .tmp file remains after success", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({ dataDir: root });
+      await store.write("task_1", makeEntry());
+      const files = await readdir(join(root, "task_1"));
+      assert.ok(
+        !files.some((f) => f.endsWith(".tmp")),
+        `unexpected .tmp file: ${files.join(",")}`,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("concurrent writes to different stepKeys in the same task all succeed", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({ dataDir: root });
+      const stepKeys = ["s1", "s2", "s3", "s4"];
+      await Promise.all(
+        stepKeys.map((stepKey) =>
+          store.write("task_1", makeEntry({ stepKey, stdout: stepKey })),
+        ),
+      );
+      for (const stepKey of stepKeys) {
+        const got = await store.read("task_1", stepKey);
+        assert.equal(got?.stdout, stepKey);
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("re-writing the same stepKey overwrites (last write wins)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({ dataDir: root });
+      await store.write("task_1", makeEntry({ stdout: "v1" }));
+      await store.write("task_1", makeEntry({ stdout: "v2" }));
+      const got = await store.read("task_1", "persona/architect");
+      assert.equal(got?.stdout, "v2");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("corrupt JSON is quarantined and read returns undefined", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const warnings: string[] = [];
+      const store = new FileCheckpointStore({
+        dataDir: root,
+        warn: (m) => warnings.push(m),
+      });
+      const stepKey = "step/corrupt";
+      const corruptPath = join(root, "task_1", fileNameFor(stepKey));
+      await mkdir(join(root, "task_1"), { recursive: true });
+      await writeFile(corruptPath, "{ not valid json", "utf8");
+
+      const got = await store.read("task_1", stepKey);
+      assert.equal(got, undefined);
+
+      // Original path should be empty after quarantine.
+      const taskFiles = await readdir(join(root, "task_1"));
+      assert.deepEqual(taskFiles, []);
+
+      // Quarantine directory should now have the file.
+      const corruptFiles = await readdir(join(root, "corrupt", "task_1"));
+      assert.equal(corruptFiles.length, 1);
+      assert.ok(warnings.some((w) => w.includes("quarantined corrupt")));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("malformed schema (missing required fields) is quarantined", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({
+        dataDir: root,
+        warn: () => {},
+      });
+      const stepKey = "step/bad";
+      const filePath = join(root, "task_1", fileNameFor(stepKey));
+      await mkdir(join(root, "task_1"), { recursive: true });
+      await writeFile(
+        filePath,
+        JSON.stringify({ version: 1, stepKey: "step/bad" }),
+        "utf8",
+      );
+      const got = await store.read("task_1", stepKey);
+      assert.equal(got, undefined);
+      const taskFiles = await readdir(join(root, "task_1"));
+      assert.deepEqual(taskFiles, []);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("unknown version returns undefined without quarantining", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({
+        dataDir: root,
+        warn: () => {},
+      });
+      const stepKey = "step/futureproof";
+      const filePath = join(root, "task_1", fileNameFor(stepKey));
+      await mkdir(join(root, "task_1"), { recursive: true });
+      await writeFile(
+        filePath,
+        JSON.stringify({
+          version: 999,
+          stepKey,
+          fingerprint: "fp",
+          tool: "claude",
+          succeededAt: "2026-05-05T12:00:00.000Z",
+          stdout: "...",
+        }),
+        "utf8",
+      );
+      const got = await store.read("task_1", stepKey);
+      assert.equal(got, undefined);
+
+      // No quarantine: the file should still be at its original path so a
+      // subsequent successful write can overwrite it.
+      const taskFiles = await readdir(join(root, "task_1"));
+      assert.equal(taskFiles.length, 1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("drop removes the entire task directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({ dataDir: root });
+      await store.write("task_1", makeEntry({ stepKey: "a" }));
+      await store.write("task_1", makeEntry({ stepKey: "b" }));
+      await store.drop("task_1");
+      const dirs = await readdir(root);
+      assert.ok(!dirs.includes("task_1"), `task_1 still present: ${dirs}`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("drop on a non-existent task is a no-op (does not throw)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({ dataDir: root });
+      await store.drop("task_never_existed");
+      // No assertion needed — survival is the test.
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("sweep removes orphan task directories and keeps active ones", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({ dataDir: root });
+      await store.write("task_active", makeEntry());
+      await store.write("task_orphan_1", makeEntry());
+      await store.write("task_orphan_2", makeEntry());
+
+      const dropped = await store.sweep(new Set(["task_active"]));
+
+      assert.equal(dropped, 2);
+      const dirs = await readdir(root);
+      assert.deepEqual(dirs.sort(), ["task_active"]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("sweep does not remove the corrupt/ quarantine directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({
+        dataDir: root,
+        warn: () => {},
+      });
+      // Trigger a quarantine.
+      const stepKey = "step/x";
+      await mkdir(join(root, "task_1"), { recursive: true });
+      await writeFile(
+        join(root, "task_1", fileNameFor(stepKey)),
+        "not json",
+        "utf8",
+      );
+      await store.read("task_1", stepKey);
+
+      // Sweep with no active tasks. Should remove task_1 but keep corrupt/.
+      const dropped = await store.sweep(new Set());
+      assert.equal(dropped, 1);
+      const dirs = await readdir(root);
+      assert.ok(dirs.includes("corrupt"));
+      assert.ok(!dirs.includes("task_1"));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("sweep on a missing dataDir returns 0 without throwing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const missingDir = join(root, "does-not-exist");
+      const store = new FileCheckpointStore({ dataDir: missingDir });
+      const dropped = await store.sweep(new Set(["task_x"]));
+      assert.equal(dropped, 0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("persisted file embeds version and round-trips fingerprint exactly", async () => {
+    const root = await mkdtemp(join(tmpdir(), "checkpoint-store-"));
+    try {
+      const store = new FileCheckpointStore({ dataDir: root });
+      const entry = makeEntry({
+        stepKey: "persona/test",
+        fingerprint: "deadbeef",
+        tool: "codex",
+      });
+      await store.write("task_1", entry);
+      const filePath = join(root, "task_1", fileNameFor(entry.stepKey));
+      const raw = await readFile(filePath, "utf8");
+      const payload = JSON.parse(raw);
+      assert.equal(payload.version, 1);
+      assert.equal(payload.fingerprint, "deadbeef");
+      assert.equal(payload.tool, "codex");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/issue-comment-reply-strategy.test.ts
+++ b/tests/unit/issue-comment-reply-strategy.test.ts
@@ -507,7 +507,7 @@ describe("issueCommentReplyStrategy", () => {
 
     assert.equal(result.status, "rate_limited");
     if (result.status !== "rate_limited") return;
-    assert.equal(result.toolName, "codex");
+    assert.deepEqual(result.toolNames, ["codex"]);
     assert.equal(postedIssueComments.length, 0);
   });
 

--- a/tests/unit/issue-initial-review-strategy.test.ts
+++ b/tests/unit/issue-initial-review-strategy.test.ts
@@ -335,7 +335,7 @@ describe("issueInitialReviewStrategy (parallel personas + publisher)", () => {
 
     assert.equal(result.status, "rate_limited");
     if (result.status !== "rate_limited") return;
-    assert.equal(result.toolName, "codex");
+    assert.deepEqual(result.toolNames, ["codex"]);
     // Only personas ran; publisher must not have been invoked.
     assert.equal(aiCalls.length, 4);
     assert.equal(postedIssueComments.length, 0);
@@ -359,7 +359,7 @@ describe("issueInitialReviewStrategy (parallel personas + publisher)", () => {
 
     assert.equal(result.status, "rate_limited");
     if (result.status !== "rate_limited") return;
-    assert.equal(result.toolName, "codex");
+    assert.deepEqual(result.toolNames, ["codex"]);
     assert.equal(postedIssueComments.length, 0);
   });
 

--- a/tests/unit/issue-initial-review-strategy.test.ts
+++ b/tests/unit/issue-initial-review-strategy.test.ts
@@ -400,4 +400,98 @@ describe("issueInitialReviewStrategy (parallel personas + publisher)", () => {
     assert.equal(aiCalls.length, 0);
     assert.equal(postedIssueComments.length, 0);
   });
+
+  test("passes a stable persona/<id> stepKey to each persona ai.run (#137)", async () => {
+    const { tk, aiCalls } = makeToolkit({ resultsByPersona: ALL_SUCCEEDED });
+
+    await issueInitialReviewStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    const personaStepKeys = aiCalls
+      .filter((call) => {
+        const frag = call.prompt.find(
+          (f) => f.kind === "file" && f.path.startsWith("personas/"),
+        );
+        return (
+          frag?.kind === "file" && frag.path !== "personas/publisher"
+        );
+      })
+      .map((call) => call.stepKey)
+      .sort();
+
+    assert.deepEqual(personaStepKeys, [
+      "persona/architect",
+      "persona/maintenance",
+      "persona/ops",
+      "persona/test",
+    ]);
+  });
+
+  test("passes stepKey 'publisher' to the publisher ai.run (#137)", async () => {
+    const { tk, aiCalls } = makeToolkit({ resultsByPersona: ALL_SUCCEEDED });
+
+    await issueInitialReviewStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    const publisherCall = aiCalls.find((call) => {
+      const frag = call.prompt.find(
+        (f) => f.kind === "file" && f.path === "personas/publisher",
+      );
+      return frag !== undefined;
+    });
+    assert.ok(publisherCall, "expected a publisher ai.run call");
+    assert.equal(publisherCall.stepKey, "publisher");
+  });
+
+  test("aggregates multiple rate-limited tools across personas into toolNames", async () => {
+    // architect runs on claude, ops/test/maintenance run on codex. Both
+    // tools 429 in the same parallel run → daemon must pause both.
+    const { tk } = makeToolkit({
+      resultsByPersona: {
+        architect: { kind: "rate_limited", toolName: "claude" },
+        test: { kind: "rate_limited", toolName: "codex" },
+        ops: { kind: "succeeded", stdout: "ops findings" },
+        maintenance: { kind: "succeeded", stdout: "maintenance findings" },
+      },
+    });
+
+    const result = await issueInitialReviewStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    assert.equal(result.status, "rate_limited");
+    if (result.status !== "rate_limited") return;
+    assert.deepEqual([...result.toolNames].sort(), ["claude", "codex"]);
+  });
+
+  test("does not duplicate a tool when multiple personas on it rate-limit", async () => {
+    // test + ops + maintenance all run on codex; if all three 429, the
+    // toolName should appear once, not three times.
+    const { tk } = makeToolkit({
+      resultsByPersona: {
+        architect: { kind: "succeeded", stdout: "architect findings" },
+        test: { kind: "rate_limited", toolName: "codex" },
+        ops: { kind: "rate_limited", toolName: "codex" },
+        maintenance: { kind: "rate_limited", toolName: "codex" },
+      },
+    });
+
+    const result = await issueInitialReviewStrategy.run(
+      task,
+      tk,
+      new AbortController().signal,
+    );
+
+    assert.equal(result.status, "rate_limited");
+    if (result.status !== "rate_limited") return;
+    assert.deepEqual([...result.toolNames], ["codex"]);
+  });
 });

--- a/tests/unit/runner-daemon.test.ts
+++ b/tests/unit/runner-daemon.test.ts
@@ -918,4 +918,257 @@ describe("RunnerDaemon", () => {
       `expected logStore write for revertToQueued failure, got: ${JSON.stringify(logCalls)}`,
     );
   });
+
+  describe("checkpoint cleanup", () => {
+    interface CheckpointSpy {
+      drops: string[];
+      sweeps: Array<readonly string[]>;
+      store: {
+        read: () => Promise<undefined>;
+        write: () => Promise<void>;
+        drop: (taskId: string) => Promise<void>;
+        sweep: (active: ReadonlySet<string>) => Promise<number>;
+      };
+    }
+
+    function makeCheckpointSpy(): CheckpointSpy {
+      const spy: CheckpointSpy = {
+        drops: [],
+        sweeps: [],
+        store: {
+          read: async () => undefined,
+          write: async () => {},
+          drop: async (taskId: string) => {
+            spy.drops.push(taskId);
+          },
+          sweep: async (active: ReadonlySet<string>) => {
+            spy.sweeps.push([...active].sort());
+            return 0;
+          },
+        },
+      };
+      return spy;
+    }
+
+    test("drops the task's checkpoint on a succeeded transition", async () => {
+      const spy = makeCheckpointSpy();
+      let currentTask = createTask("queued");
+
+      const daemon = new RunnerDaemon({
+        queueStore: {
+          enqueue: async () => currentTask,
+          listTasks: async () => [currentTask],
+          getTask: async () => currentTask,
+          startTask: async (taskId) => {
+            currentTask = {
+              ...currentTask,
+              status: "running",
+              startedAt: "2026-05-05T00:01:00.000Z",
+            };
+            void taskId;
+            return currentTask;
+          },
+          completeTask: async (_id, input) => {
+            currentTask = { ...currentTask, status: input.status };
+            return currentTask;
+          },
+          revertToQueued: async () => currentTask,
+          findQueuedBySource: async () => [],
+          markSuperseded: async () => {
+            throw new Error("markSuperseded not exercised in this test");
+          },
+          recoverRunningTasks: async () => {},
+          pruneTerminalTasks: async () => 0,
+        },
+        schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+        toolsForTask: stubToolsForTask,
+        runStrategy: async () => ({ status: "succeeded" }),
+        logStore: { write: async () => {}, cleanupExpired: async () => {} },
+        pollIntervalMs: 10,
+        checkpointStore: spy.store,
+      });
+
+      await daemon.tick();
+      await daemon.waitForIdle();
+
+      assert.deepEqual(spy.drops, ["task_1"]);
+    });
+
+    test("drops the task's checkpoint on a failed transition", async () => {
+      const spy = makeCheckpointSpy();
+      let currentTask = createTask("queued");
+
+      const daemon = new RunnerDaemon({
+        queueStore: {
+          enqueue: async () => currentTask,
+          listTasks: async () => [currentTask],
+          getTask: async () => currentTask,
+          startTask: async (taskId) => {
+            currentTask = {
+              ...currentTask,
+              status: "running",
+              startedAt: "2026-05-05T00:01:00.000Z",
+            };
+            void taskId;
+            return currentTask;
+          },
+          completeTask: async (_id, input) => {
+            currentTask = { ...currentTask, status: input.status };
+            return currentTask;
+          },
+          revertToQueued: async () => currentTask,
+          findQueuedBySource: async () => [],
+          markSuperseded: async () => {
+            throw new Error("markSuperseded not exercised in this test");
+          },
+          recoverRunningTasks: async () => {},
+          pruneTerminalTasks: async () => 0,
+        },
+        schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+        toolsForTask: stubToolsForTask,
+        runStrategy: async () => {
+          throw new Error("strategy blew up");
+        },
+        logStore: { write: async () => {}, cleanupExpired: async () => {} },
+        pollIntervalMs: 10,
+        checkpointStore: spy.store,
+      });
+
+      await daemon.tick();
+      await daemon.waitForIdle();
+
+      assert.deepEqual(spy.drops, ["task_1"]);
+    });
+
+    test("does NOT drop the checkpoint on a rate_limited transition", async () => {
+      const spy = makeCheckpointSpy();
+      let currentTask = createTask("queued");
+
+      const daemon = new RunnerDaemon({
+        queueStore: {
+          enqueue: async () => currentTask,
+          listTasks: async () => [currentTask],
+          getTask: async () => currentTask,
+          startTask: async (taskId) => {
+            currentTask = {
+              ...currentTask,
+              status: "running",
+              startedAt: "2026-05-05T00:01:00.000Z",
+            };
+            void taskId;
+            return currentTask;
+          },
+          completeTask: async () => {
+            throw new Error("completeTask not called for rate_limited");
+          },
+          revertToQueued: async () => {
+            currentTask = { ...currentTask, status: "queued" };
+            return currentTask;
+          },
+          findQueuedBySource: async () => [],
+          markSuperseded: async () => {
+            throw new Error("markSuperseded not exercised in this test");
+          },
+          recoverRunningTasks: async () => {},
+          pruneTerminalTasks: async () => 0,
+        },
+        schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+        toolsForTask: stubToolsForTask,
+        runStrategy: async () => ({
+          status: "rate_limited",
+          toolNames: ["claude"],
+        }),
+        logStore: { write: async () => {}, cleanupExpired: async () => {} },
+        pollIntervalMs: 10,
+        rateLimit: {
+          store: {
+            loadActivePauses: async () => new Map(),
+            pause: async () => {},
+          },
+          cooldownMs: 60_000,
+        },
+        checkpointStore: spy.store,
+      });
+
+      await daemon.tick();
+      await daemon.waitForIdle();
+
+      assert.deepEqual(
+        spy.drops,
+        [],
+        "rate_limited must preserve the checkpoint cache for the next retry",
+      );
+    });
+
+    test("drops the old task's checkpoint when supersede succeeds", async () => {
+      const spy = makeCheckpointSpy();
+      const oldTask = { ...createTask("queued"), taskId: "task_old" };
+
+      const daemon = new RunnerDaemon({
+        queueStore: {
+          enqueue: async () => oldTask,
+          listTasks: async () => [oldTask],
+          getTask: async () => oldTask,
+          startTask: async () => oldTask,
+          completeTask: async () => oldTask,
+          revertToQueued: async () => oldTask,
+          findQueuedBySource: async () => [],
+          markSuperseded: async () => ({ ...oldTask, status: "superseded" }),
+          recoverRunningTasks: async () => {},
+          pruneTerminalTasks: async () => 0,
+        },
+        schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+        toolsForTask: stubToolsForTask,
+        runStrategy: async () => ({ status: "succeeded" }),
+        logStore: { write: async () => {}, cleanupExpired: async () => {} },
+        pollIntervalMs: 10,
+        checkpointStore: spy.store,
+      });
+
+      await daemon.supersede("task_old", "task_new");
+
+      assert.deepEqual(spy.drops, ["task_old"]);
+    });
+
+    test("sweeps orphan checkpoint dirs at initialize using queued+running ids", async () => {
+      const spy = makeCheckpointSpy();
+      const queuedTask = { ...createTask("queued"), taskId: "task_q" };
+      const runningTask = {
+        ...createTask("running"),
+        taskId: "task_r",
+        startedAt: "2026-05-05T00:01:00.000Z",
+      };
+      const succeededTask = {
+        ...createTask("succeeded"),
+        taskId: "task_s",
+        finishedAt: "2026-05-05T00:02:00.000Z",
+      };
+
+      const daemon = new RunnerDaemon({
+        queueStore: {
+          enqueue: async () => queuedTask,
+          listTasks: async () => [queuedTask, runningTask, succeededTask],
+          getTask: async () => queuedTask,
+          startTask: async () => queuedTask,
+          completeTask: async () => queuedTask,
+          revertToQueued: async () => queuedTask,
+          findQueuedBySource: async () => [],
+          markSuperseded: async () => queuedTask,
+          recoverRunningTasks: async () => {},
+          pruneTerminalTasks: async () => 0,
+        },
+        schedulerService: new SchedulerService({ maxConcurrency: 2 }),
+        toolsForTask: stubToolsForTask,
+        runStrategy: async () => ({ status: "succeeded" }),
+        logStore: { write: async () => {}, cleanupExpired: async () => {} },
+        pollIntervalMs: 10,
+        checkpointStore: spy.store,
+      });
+
+      await daemon.initialize();
+
+      assert.equal(spy.sweeps.length, 1);
+      assert.deepEqual(spy.sweeps[0], ["task_q", "task_r"]);
+    });
+  });
 });

--- a/tests/unit/runner-daemon.test.ts
+++ b/tests/unit/runner-daemon.test.ts
@@ -129,7 +129,7 @@ describe("RunnerDaemon", () => {
       toolsForTask: stubToolsForTask,
       runStrategy: async () => {
         calls.push("execute");
-        return { status: "rate_limited", toolName: "claude" };
+        return { status: "rate_limited", toolNames: ["claude"] };
       },
       logStore: {
         write: async (taskId, message) => {
@@ -276,7 +276,7 @@ describe("RunnerDaemon", () => {
       },
       schedulerService: new SchedulerService({ maxConcurrency: 2 }),
       toolsForTask: stubToolsForTask,
-      runStrategy: async () => ({ status: "rate_limited", toolName: "claude" }),
+      runStrategy: async () => ({ status: "rate_limited", toolNames: ["claude"] }),
       logStore: {
         write: async () => {},
         cleanupExpired: async () => {},
@@ -444,7 +444,7 @@ describe("RunnerDaemon", () => {
       toolsForTask: stubToolsForTask,
       runStrategy: async () => ({
         status: "rate_limited",
-        toolName: "claude",
+        toolNames: ["claude"],
       }),
       logStore: {
         write: async () => {},
@@ -882,7 +882,7 @@ describe("RunnerDaemon", () => {
       toolsForTask: stubToolsForTask,
       runStrategy: async () => ({
         status: "rate_limited",
-        toolName: "claude",
+        toolNames: ["claude"],
       }),
       logStore: {
         write: async (taskId, message) => {

--- a/tests/unit/toolkit.test.ts
+++ b/tests/unit/toolkit.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import type { GitHubSourceContext } from "../../src/domain/github.js";
+import type {
+  CheckpointEntry,
+  CheckpointStore,
+} from "../../src/domain/ports/checkpoint-store.js";
 import type { GitHubClient } from "../../src/domain/ports/github-client.js";
 import type { LogStore } from "../../src/domain/ports/log-store.js";
 import type { ToolRunner } from "../../src/domain/ports/tool-runner.js";
@@ -10,6 +14,36 @@ import type { ToolRunInput, ToolRunResult } from "../../src/domain/tool.js";
 import type { PromptRenderer } from "../../src/infra/prompts/prompt-renderer.js";
 import { ToolkitFactory } from "../../src/services/toolkit.js";
 import type { ToolRegistry } from "../../src/services/tool-registry.js";
+
+class InMemoryCheckpointStore implements CheckpointStore {
+  readonly entries = new Map<string, CheckpointEntry>();
+  readonly drops: string[] = [];
+
+  private key(taskId: string, stepKey: string): string {
+    return `${taskId}::${stepKey}`;
+  }
+
+  async read(taskId: string, stepKey: string): Promise<CheckpointEntry | undefined> {
+    return this.entries.get(this.key(taskId, stepKey));
+  }
+
+  async write(taskId: string, entry: CheckpointEntry): Promise<void> {
+    this.entries.set(this.key(taskId, entry.stepKey), entry);
+  }
+
+  async drop(taskId: string): Promise<void> {
+    this.drops.push(taskId);
+    for (const key of [...this.entries.keys()]) {
+      if (key.startsWith(`${taskId}::`)) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  async sweep(): Promise<number> {
+    return 0;
+  }
+}
 
 const task: TaskRecord = {
   taskId: "task_tk_1",
@@ -38,6 +72,7 @@ interface RunnerCall {
 function buildToolkit(opts: {
   declared: readonly string[];
   runners?: Record<string, ToolRunner>;
+  checkpointStore?: CheckpointStore;
 }) {
   const calls: RunnerCall[] = [];
   const cleanups: string[] = [];
@@ -94,8 +129,11 @@ function buildToolkit(opts: {
       return "rendered prompt";
     },
   } as unknown as PromptRenderer;
+  const logCalls: Array<{ taskId: string; message: string }> = [];
   const logStore = {
-    write: async () => {},
+    write: async (taskId: string, message: string) => {
+      logCalls.push({ taskId, message });
+    },
   } as unknown as LogStore;
 
   const factory = new ToolkitFactory({
@@ -105,8 +143,11 @@ function buildToolkit(opts: {
     logStore,
     promptRenderer,
     toolsForTask: () => opts.declared,
+    ...(opts.checkpointStore !== undefined
+      ? { checkpointStore: opts.checkpointStore }
+      : {}),
   });
-  return { factory, calls, cleanups, renderCalls };
+  return { factory, calls, cleanups, renderCalls, logCalls };
 }
 
 describe("ToolkitFactory.create", () => {
@@ -305,5 +346,212 @@ describe("toolkit cleanup fan-out", () => {
       "claude:/tmp/ws",
       "codex:/tmp/ws",
     ]);
+  });
+});
+
+describe("toolkit.ai.run — checkpoint caching", () => {
+  test("does not consult the cache when stepKey is omitted", async () => {
+    const checkpointStore = new InMemoryCheckpointStore();
+    const { factory, calls } = buildToolkit({
+      declared: ["claude"],
+      checkpointStore,
+    });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    await tk.ai.run({
+      prompt: [{ kind: "literal", text: "no key" }],
+    });
+    await tk.ai.run({
+      prompt: [{ kind: "literal", text: "no key" }],
+    });
+
+    assert.equal(calls.length, 2);
+    assert.equal(checkpointStore.entries.size, 0);
+  });
+
+  test("does not consult the cache when no checkpointStore is wired", async () => {
+    const { factory, calls } = buildToolkit({ declared: ["claude"] });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    await tk.ai.run({
+      stepKey: "step/a",
+      prompt: [{ kind: "literal", text: "hi" }],
+    });
+    await tk.ai.run({
+      stepKey: "step/a",
+      prompt: [{ kind: "literal", text: "hi" }],
+    });
+
+    assert.equal(calls.length, 2);
+  });
+
+  test("writes to the cache on success and serves the stored stdout on the next call", async () => {
+    const checkpointStore = new InMemoryCheckpointStore();
+    const { factory, calls, logCalls } = buildToolkit({
+      declared: ["claude"],
+      checkpointStore,
+    });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    const first = await tk.ai.run({
+      stepKey: "persona/architect",
+      prompt: [{ kind: "literal", text: "x" }],
+    });
+    assert.equal(first.kind, "succeeded");
+    if (first.kind !== "succeeded") return;
+    assert.equal(first.stdout, "ok-from-claude");
+    assert.equal(calls.length, 1);
+    assert.equal(checkpointStore.entries.size, 1);
+
+    const second = await tk.ai.run({
+      stepKey: "persona/architect",
+      prompt: [{ kind: "literal", text: "x" }],
+    });
+    assert.equal(second.kind, "succeeded");
+    if (second.kind !== "succeeded") return;
+    assert.equal(second.stdout, "ok-from-claude");
+    // Runner not called the second time.
+    assert.equal(calls.length, 1);
+    // Logged the hit.
+    assert.ok(
+      logCalls.some((c) =>
+        c.message.includes("checkpoint hit step=persona/architect"),
+      ),
+      `expected hit log, got: ${JSON.stringify(logCalls)}`,
+    );
+  });
+
+  test("treats a fingerprint mismatch as a miss and re-runs the runner", async () => {
+    const checkpointStore = new InMemoryCheckpointStore();
+    const { factory, calls } = buildToolkit({
+      declared: ["claude"],
+      checkpointStore,
+    });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    await tk.ai.run({
+      stepKey: "step/x",
+      prompt: [{ kind: "literal", text: "first prompt" }],
+    });
+    assert.equal(calls.length, 1);
+
+    // Manually corrupt the stored fingerprint to simulate input drift
+    // (e.g. issue body edited between retries → rendered prompt changes).
+    const stored = await checkpointStore.read(task.taskId, "step/x");
+    assert.ok(stored !== undefined);
+    if (stored === undefined) return;
+    await checkpointStore.write(task.taskId, {
+      ...stored,
+      fingerprint: "stale-fp",
+    });
+
+    await tk.ai.run({
+      stepKey: "step/x",
+      prompt: [{ kind: "literal", text: "first prompt" }],
+    });
+    assert.equal(calls.length, 2);
+  });
+
+  test("treats a tool mismatch as a miss (same stepKey but different tool)", async () => {
+    const checkpointStore = new InMemoryCheckpointStore();
+    const { factory, calls } = buildToolkit({
+      declared: ["claude", "codex"],
+      checkpointStore,
+    });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    await tk.ai.run({
+      tool: "claude",
+      stepKey: "step/y",
+      prompt: [{ kind: "literal", text: "z" }],
+    });
+    assert.equal(calls.length, 1);
+
+    // Same stepKey, different tool → cache must miss.
+    await tk.ai.run({
+      tool: "codex",
+      stepKey: "step/y",
+      prompt: [{ kind: "literal", text: "z" }],
+    });
+    assert.equal(calls.length, 2);
+  });
+
+  test("does not write the cache for a failed runner result", async () => {
+    const checkpointStore = new InMemoryCheckpointStore();
+    const failingRunner: ToolRunner = {
+      run: async () => ({
+        kind: "failed",
+        stdout: "",
+        stderr: "exec failed",
+        exitCode: 1,
+      }),
+      cleanupArtifacts: async () => {},
+    };
+    const { factory } = buildToolkit({
+      declared: ["claude"],
+      runners: { claude: failingRunner },
+      checkpointStore,
+    });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    const result = await tk.ai.run({
+      stepKey: "step/will-fail",
+      prompt: [{ kind: "literal", text: "p" }],
+    });
+    assert.equal(result.kind, "failed");
+    assert.equal(checkpointStore.entries.size, 0);
+  });
+
+  test("does not write the cache for a rate_limited runner result", async () => {
+    const checkpointStore = new InMemoryCheckpointStore();
+    const limitingRunner: ToolRunner = {
+      run: async () => ({
+        kind: "rate_limited",
+        toolName: "claude",
+        signal: "429",
+      }),
+      cleanupArtifacts: async () => {},
+    };
+    const { factory } = buildToolkit({
+      declared: ["claude"],
+      runners: { claude: limitingRunner },
+      checkpointStore,
+    });
+    const tk = factory.create(task);
+
+    await using ws = await tk.workspace.prepareObserve(task);
+    void ws;
+    await tk.github.fetchContext(task);
+
+    const result = await tk.ai.run({
+      stepKey: "step/will-429",
+      prompt: [{ kind: "literal", text: "p" }],
+    });
+    assert.equal(result.kind, "rate_limited");
+    assert.equal(checkpointStore.entries.size, 0);
   });
 });


### PR DESCRIPTION
## Summary

When one task makes multiple AI calls (e.g. `issue-initial-review` runs 4 persona analyses in parallel) and a single inner call 429s, today the entire task is requeued and every successful inner call is redone after the 30 min cooldown. This PR adds a per-task on-disk cache so successful AI step results survive a retry and only the still-rate-limited step re-invokes its runner.

User-facing API surface for strategy authors: **one new optional field, `stepKey`, on `tk.ai.run`.** The fingerprint that protects against stale cache (issue body edited between retries, etc.) is computed inside the toolkit from the rendered prompt + tool + intensity + allow/disallow + outputSchema — strategies don't manage it.

## Architecture (6 atomic commits)

1. **Storage layer** — `CheckpointStore` port + `FileCheckpointStore` (`<dataDir>/<taskId>/<sha256(stepKey).slice(0,16)>.json`), atomic tmp+rename, corrupt JSON quarantine, forward-compatible version field, `drop` and `sweep`.
2. **Multi-tool rate-limit signal** — `ExecuteResult.rate_limited` carries `toolNames: readonly string[]` instead of a single tool. Lets a parallel-fanout strategy (claude+codex personas) surface every tool that 429'd in the same run so the daemon pauses all of them. Single-tool strategies migrate transparently via `mapAiFailure`.
3. **Toolkit cache** — `ai.run` reads before invoking the runner (cache hit on stepKey + fingerprint + tool match) and writes on success. Failed and rate_limited results are intentionally not cached. Both `stepKey` AND `checkpointStore` must be present to activate; either alone is a no-op.
4. **Daemon cleanup** — drop on succeeded / failed / superseded / sweepStaleRunning. **rate_limited intentionally bypasses drop** so the next retry can serve hits. Startup sweep removes orphan dirs left by crashes.
5. **Composition root** — wire `FileCheckpointStore` at `<RUNNER_ROOT>/var/checkpoints/`.
6. **Strategy adoption** — `issue-initial-review` tags persona calls with `stepKey: persona/<id>` and the publisher with `stepKey: publisher`.

## What this fixes for `issue-initial-review`

Today: 1 ops-persona 429 → all 4 personas redone after 30 min (1 wasted claude inference, 2 wasted codex inferences).
After this PR: 1 ops-persona 429 → architect/test/maintenance served from disk, only ops persona + publisher re-invoked.

## Test plan

- [x] `npm run build` — typecheck clean
- [x] `npm test` — **310/310** (was 279 on main, +31 new)
  - 15 cases for `FileCheckpointStore`: CRUD, atomicity, concurrent writes, corrupt JSON quarantine, schema-malformed quarantine, unknown-version forward-compat, drop, drop-noexist, sweep keep-active, sweep skip-corrupt-dir, sweep missing-dataDir, persisted-file shape
  - 7 cases for toolkit cache: no-stepKey passthrough, no-store passthrough, hit, fingerprint mismatch, tool mismatch, no-cache-on-failed, no-cache-on-rate_limited
  - 5 cases for daemon cleanup: drop on succeeded, drop on failed, **no drop on rate_limited**, drop on superseded, startup sweep with queued+running set
  - 4 cases for issue-initial-review: stable persona/<id> stepKey, publisher stepKey, multi-tool aggregation, dedup
- [ ] Production check after deploy: log line `[ai.run] checkpoint hit step=...` should appear on a retry that follows a single-persona 429; `[daemon] checkpoint sweep dropped N orphan dir(s)` should be 0 in steady state

## Out of scope (separate issues)

- `tk.github.*` idempotence — not retry-safe; checkpointing them needs a different design
- Checkpoint expiry / size limits — terminal-transition drop keeps the directory bounded; a long-stuck task could accumulate, but that's also a queue-level smell
- Distributed daemon — single daemon assumed
- Other strategies adopting `stepKey` — point fix here is the multi-step strategy that hits this most often; widening adoption is a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)