### PR TITLE
feat(github): retry transient errors (5xx, network throws) in fetch wrapper

### DIFF
--- a/src/infra/github/github-fetch.ts
+++ b/src/infra/github/github-fetch.ts
@@ -40,6 +40,20 @@ export interface GithubFetchOptions {
    * self-correcting check cycle.
    */
   cooldownMs?: number;
+  /**
+   * Max retries for transient errors (network-level throws and 5xx
+   * responses on 500/502/503/504). Total attempts = limit + 1. Default 2,
+   * so a flaky request gets up to 3 tries before surfacing. Rate-limit
+   * (429 / depleted-quota 403) has its own one-shot path and is not
+   * counted here. Permanent 4xx and 501 fall through unchanged.
+   */
+  transientRetryLimit?: number;
+  /**
+   * Base backoff (ms) for transient retries. Each attempt waits
+   * baseMs * 3^attempt — defaults 500ms / 1500ms with 2 retries, ~2s
+   * worst-case before the call surfaces.
+   */
+  transientBackoffBaseMs?: number;
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
   fetchImpl?: typeof fetch;
@@ -50,6 +64,8 @@ interface ResolvedOptions {
   proactiveThreshold: number;
   inlineRetryThresholdMs: number;
   cooldownMs: number;
+  transientRetryLimit: number;
+  transientBackoffBaseMs: number;
   now: () => number;
   sleep: (ms: number) => Promise<void>;
   fetchImpl: typeof fetch;
@@ -58,6 +74,8 @@ interface ResolvedOptions {
 const DEFAULT_PROACTIVE_THRESHOLD = 500;
 const DEFAULT_INLINE_RETRY_THRESHOLD_MS = 60_000;
 const DEFAULT_COOLDOWN_MS = 30 * 60_000;
+const DEFAULT_TRANSIENT_RETRY_LIMIT = 2;
+const DEFAULT_TRANSIENT_BACKOFF_BASE_MS = 500;
 
 export interface GithubFetcher {
   request(url: string, init?: RequestInit): Promise<Response>;
@@ -73,6 +91,10 @@ export function createGithubFetcher(
     inlineRetryThresholdMs:
       options?.inlineRetryThresholdMs ?? DEFAULT_INLINE_RETRY_THRESHOLD_MS,
     cooldownMs: options?.cooldownMs ?? DEFAULT_COOLDOWN_MS,
+    transientRetryLimit:
+      options?.transientRetryLimit ?? DEFAULT_TRANSIENT_RETRY_LIMIT,
+    transientBackoffBaseMs:
+      options?.transientBackoffBaseMs ?? DEFAULT_TRANSIENT_BACKOFF_BASE_MS,
     now: options?.now ?? (() => Date.now()),
     sleep:
       options?.sleep ??
@@ -81,7 +103,7 @@ export function createGithubFetcher(
   };
 
   return {
-    request: (url, init) => doRequest(url, init, cfg, 0),
+    request: (url, init) => doRequest(url, init, cfg, 0, 0),
   };
 }
 
@@ -90,8 +112,34 @@ async function doRequest(
   init: RequestInit | undefined,
   cfg: ResolvedOptions,
   attempt: number,
+  transientAttempt: number,
 ): Promise<Response> {
-  const response = await cfg.fetchImpl(url, init ?? {});
+  // Network-level throws (DNS, ECONNRESET, TLS handshake, fetch abort)
+  // are indistinguishable from transient infrastructure failures from the
+  // caller's point of view, so they share the 5xx retry budget. Note: a
+  // POST that timed out at the network layer AFTER the server processed
+  // it may produce a duplicate on retry — the existing rate-limit retry
+  // path on line 110 has the same property and we accept that trade-off
+  // here for the same reason: cleanup reliability beats the rare dup.
+  let response: Response;
+  try {
+    response = await cfg.fetchImpl(url, init ?? {});
+  } catch (error) {
+    if (transientAttempt < cfg.transientRetryLimit) {
+      await cfg.sleep(transientBackoffMs(transientAttempt, cfg));
+      return doRequest(url, init, cfg, attempt, transientAttempt + 1);
+    }
+    throw error;
+  }
+
+  if (
+    isTransientServerError(response) &&
+    transientAttempt < cfg.transientRetryLimit
+  ) {
+    await cfg.sleep(transientBackoffMs(transientAttempt, cfg));
+    return doRequest(url, init, cfg, attempt, transientAttempt + 1);
+  }
+
   await maybeProactivePause(response, cfg);
 
   if (!isRateLimitResponse(response)) {
@@ -103,12 +151,27 @@ async function doRequest(
 
   if (retryAfterMs <= cfg.inlineRetryThresholdMs && attempt === 0) {
     await cfg.sleep(Math.max(retryAfterMs, 0));
-    return doRequest(url, init, cfg, attempt + 1);
+    return doRequest(url, init, cfg, attempt + 1, transientAttempt);
   }
 
   const pausedUntil = cfg.now() + Math.max(retryAfterMs, cfg.cooldownMs);
   await safePause(cfg.pauseSink, pausedUntil);
   throw new GithubRateLimitedError({ kind, retryAfterMs, pausedUntil });
+}
+
+// 500, 502, 503, 504 are treated as transient. 501 (Not Implemented) is
+// permanent server-side and not retried. Other 5xx codes (e.g. 507/508)
+// are uncommon enough on the GitHub API surface to ignore.
+function isTransientServerError(response: Response): boolean {
+  const s = response.status;
+  return s === 500 || s === 502 || s === 503 || s === 504;
+}
+
+function transientBackoffMs(
+  transientAttempt: number,
+  cfg: ResolvedOptions,
+): number {
+  return cfg.transientBackoffBaseMs * 3 ** transientAttempt;
 }
 
 async function maybeProactivePause(

--- a/tests/unit/github-fetch.test.ts
+++ b/tests/unit/github-fetch.test.ts
@@ -261,6 +261,135 @@ describe("createGithubFetcher", () => {
     );
   });
 
+  test("retries a network-level throw and succeeds", async () => {
+    const calls: string[] = [];
+    let i = 0;
+    const fetchImpl = (async (input: string | URL) => {
+      calls.push(typeof input === "string" ? input : String(input));
+      i += 1;
+      if (i === 1) {
+        throw new TypeError("fetch failed: ECONNRESET");
+      }
+      return makeResponse({ status: 200 });
+    }) as typeof fetch;
+
+    const slept: number[] = [];
+    const fetcher = createGithubFetcher({
+      transientRetryLimit: 2,
+      transientBackoffBaseMs: 10,
+      sleep: async (ms) => void slept.push(ms),
+      fetchImpl,
+    });
+    const res = await fetcher.request("https://api/x");
+    assert.equal(res.status, 200);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(slept, [10]);
+  });
+
+  test("exhausts the transient retry budget on repeated network throws and rethrows the last error", async () => {
+    let i = 0;
+    const fetchImpl = (async () => {
+      i += 1;
+      throw new TypeError(`net throw #${i}`);
+    }) as typeof fetch;
+
+    const fetcher = createGithubFetcher({
+      transientRetryLimit: 2,
+      transientBackoffBaseMs: 1,
+      sleep: async () => {},
+      fetchImpl,
+    });
+    await assert.rejects(
+      fetcher.request("https://api/x"),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.equal(error.message, "net throw #3");
+        return true;
+      },
+    );
+    assert.equal(i, 3, "must attempt limit + 1 times before giving up");
+  });
+
+  test("retries a 503 response and returns the eventual success", async () => {
+    const { fetchImpl, calls } = makeFetchImpl([
+      { status: 503 },
+      { status: 502 },
+      { status: 200 },
+    ]);
+    const slept: number[] = [];
+    const fetcher = createGithubFetcher({
+      transientRetryLimit: 2,
+      transientBackoffBaseMs: 10,
+      sleep: async (ms) => void slept.push(ms),
+      fetchImpl,
+    });
+    const res = await fetcher.request("https://api/x");
+    assert.equal(res.status, 200);
+    assert.equal(calls.length, 3);
+    // attempt 0 backoff = 10, attempt 1 backoff = 30
+    assert.deepEqual(slept, [10, 30]);
+  });
+
+  test("returns the final 5xx unchanged when transient retries are exhausted", async () => {
+    const { fetchImpl, calls } = makeFetchImpl([
+      { status: 503 },
+      { status: 503 },
+      { status: 503 },
+    ]);
+    const fetcher = createGithubFetcher({
+      transientRetryLimit: 2,
+      transientBackoffBaseMs: 1,
+      sleep: async () => {},
+      fetchImpl,
+    });
+    const res = await fetcher.request("https://api/x");
+    assert.equal(res.status, 503);
+    assert.equal(calls.length, 3);
+  });
+
+  test("does not retry 501 Not Implemented", async () => {
+    const { fetchImpl, calls } = makeFetchImpl([{ status: 501 }]);
+    const fetcher = createGithubFetcher({
+      transientRetryLimit: 2,
+      transientBackoffBaseMs: 1,
+      sleep: async () => {},
+      fetchImpl,
+    });
+    const res = await fetcher.request("https://api/x");
+    assert.equal(res.status, 501);
+    assert.equal(calls.length, 1);
+  });
+
+  test("does not retry permanent 4xx like 404 or 422", async () => {
+    const { fetchImpl, calls } = makeFetchImpl([{ status: 404 }]);
+    const fetcher = createGithubFetcher({
+      transientRetryLimit: 2,
+      sleep: async () => {},
+      fetchImpl,
+    });
+    const res = await fetcher.request("https://api/x");
+    assert.equal(res.status, 404);
+    assert.equal(calls.length, 1);
+  });
+
+  test("503 followed by a 429 still triggers the rate-limit one-shot path", async () => {
+    const { fetchImpl, calls } = makeFetchImpl([
+      { status: 503 },
+      { status: 429, headers: { "retry-after": "1" } },
+      { status: 200 },
+    ]);
+    const fetcher = createGithubFetcher({
+      transientRetryLimit: 2,
+      transientBackoffBaseMs: 1,
+      inlineRetryThresholdMs: 60_000,
+      sleep: async () => {},
+      fetchImpl,
+    });
+    const res = await fetcher.request("https://api/x");
+    assert.equal(res.status, 200);
+    assert.equal(calls.length, 3);
+  });
+
   test("GithubRateLimitedError.pausedUntil is at least now+cooldown floor", async () => {
     const clock = makeClock(1_000_000);
     // Retry-After 0 means "we don't know"; fallback to cooldown floor.


### PR DESCRIPTION
## Summary

- `createGithubFetcher`'s `doRequest` now retries network-level throws (DNS, ECONNRESET, TLS, fetch abort) and 5xx responses on 500/502/503/504, sharing a single retry budget (`transientRetryLimit`, default 2 → 3 total attempts) with exponential backoff (`transientBackoffBaseMs` × 3^attempt, default 500ms / 1500ms).
- 501 (Not Implemented) and other 5xx codes pass through unchanged — those are permanent. 4xx (404, 422, …) also unchanged.
- The existing rate-limit one-shot path is untouched: it uses its own `attempt` counter, so a 5xx → 429 sequence still gets the rate-limit retry. POST duplication risk on a network-throw retry exists in theory, same as the rate-limit retry already on line 110, and is accepted for the same reason (cleanup reliability > rare dup).

## Why

Closes the residual gap that PR #149 left for issue #128. PR #149 wired GitHub rate-limit signals (429 / depleted-quota 403) into the daemon pause/retry flow, but generic transient failures — 5xx and network-level throws — still surfaced as single-shot errors. In the sticky-comment cleanup path (`onSucceeded` / `onFailure` in `src/index.ts`) that meant one transient blip stranded the sticky on the thread.

This PR is intentionally limited to the **option-A scope** of #128. Option B (startup reconciliation pass over terminal tasks with dangling stickies) involves queue-store schema, prune ordering, and `completeTask` callback ordering changes; per discussion it's left as a follow-up if stranded stickies recur in practice now that transient retry covers the dominant failure modes.

## Test plan

- [x] `npm run build` (tsc --noEmit) — clean
- [x] `npm test` — 334/334 passing, including 7 new cases:
  - retries a network-level throw and succeeds
  - exhausts the transient retry budget on repeated network throws and rethrows the last error
  - retries a 503 response and returns the eventual success
  - returns the final 5xx unchanged when transient retries are exhausted
  - does not retry 501 Not Implemented
  - does not retry permanent 4xx like 404 or 422
  - 503 followed by a 429 still triggers the rate-limit one-shot path
- [ ] Watch the daemon journal post-deploy for any change in `failed to delete sticky comment` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)