### PR TITLE
chore(gitignore): ignore .claude/ local agent settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp/
 var/
 *.log
 .omc/
+.claude/


### PR DESCRIPTION
## 변경의 핵심

`.claude/` 디렉토리(Claude Code의 로컬 에이전트 설정)를 gitignore에 추가. `.omc/`와 동일하게 사용자별 로컬 도구 산출물이라 트래킹 대상이 아님.

## 검증

- `git status`에 `.claude/`가 더 이상 untracked로 표시되지 않음.